### PR TITLE
use actions instead of jobs; separate repositories from actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This repository will contain the work of [my](https://github.com/reschandreas) master's thesis. The goal of this thesis is to create a domain-specific language (DSL) for streamlining CI job configuration for programming exercises.
 
 ## Why?
-Currently, in Artemis, it is tiresome to configure CI jobs that deviate from the standard templates.
-Aeolus should help to make the configuration easier, more readable and most importantly more platform-independent.
+Currently, in Artemis, it is hard to create custom CI jobs. With Aeolus we provide a standard definition that 
+is able to generate code for several targets.
 
 ## How?
-The idea is to define an input grammar, parse and validate it and generate the CI configuration 
+The idea is to define an input language, parse and validate it and generate the CI configuration 
 for multiple platforms (e.g. CLI, Bamboo, Jenkins, ...). And therefore be able to 
 switch the CI platform without having to rewrite the configuration.
 
@@ -31,7 +31,7 @@ metadata:
   description: This is a windfile with an internal action
   author: Andreas Resch
   gitCredentials: artemis_gitlab_admin_credentials
-jobs:
+actions:
   clone:
     use: clone-default
     parameters:
@@ -73,12 +73,11 @@ The generated CLI script for the above example would look like this:
 ```bash
 #!/usr/bin/env bash
 set -e
-# step clone
-# generated from step clone
-# original type was clone-default
-clone () {
-  echo '🖨️ cloning clone'
-  git clone https://github.com/ls1intum/Aeolus.git .
+# step aeolus
+# generated from repository aeolus
+clone_aeolus () {
+  echo '🖨️ cloning aeolus'
+  git clone https://github.com/ls1intum/Aeolus.git --branch develop .
 }
 # step internal-action
 # generated from step internal-action
@@ -105,7 +104,7 @@ external-action () {
 # main function
 main () {
   local _current_lifecycle="${1}"
-  clone $_current_lifecycle
+  clone_aeolus $_current_lifecycle
   internal-action $_current_lifecycle
   external-action $_current_lifecycle
 }
@@ -124,7 +123,7 @@ pipeline {
     string(name: 'current_lifecycle', defaultValue: 'working_time', description: 'The current lifecycle')
   }
   stages {
-    stage('clone') {
+    stage('aeolus') {
       steps {
         checkout([$class: 'GitSCM',
                   branches: [[name: 'develop']],
@@ -132,10 +131,10 @@ pipeline {
                   extensions: [],
                   submoduleCfg: [],
                   userRemoteConfigs: [[
-                    credentialsId: 'artemis_gitlab_admin_credentials',
-                    name: 'clone',
-                    url: 'https://github.com/ls1intum/Aeolus.git'
-                  ]]
+                                              credentialsId: 'artemis_gitlab_admin_credentials',
+                                              name: 'aeolus',
+                                              url: 'https://github.com/ls1intum/Aeolus.git'
+                                      ]]
         ])
       }
     }
@@ -144,6 +143,7 @@ pipeline {
     // original type was internal
     stage('internal-action') {
       steps {
+        echo '⚙️ executing internal-action'
         sh '''
          echo "This is an internal action"
         '''
@@ -162,6 +162,7 @@ pipeline {
         WHO_TO_GREET = "world"
       }
       steps {
+        echo '⚙️ executing external-action'
         sh '''
          echo "Hello ${WHO_TO_GREET}"
         '''

--- a/cli/classes/generated/definitions.py
+++ b/cli/classes/generated/definitions.py
@@ -56,6 +56,18 @@ class ContactData(BaseModel):
     email: Optional[str] = Field(None, description='The email of the author.', examples=['aeolus@resch.io'])
 
 
+class Repository(BaseModel):
+    """
+    Repository to be checked out during the execution of the actions
+    """
+
+    url: str = Field(..., description='The url of the repository', examples=['https://github.com/ls1intum/Aeolus.git'])
+    branch: str = Field(..., description='The branch to check out', examples=['main'])
+    path: str = Field(
+        ..., description='The path where the content of the repository should be checked out', examples=['.', 'tests']
+    )
+
+
 class GitCredentials(BaseModel):
     """
     Git credentials that are used to clone the repositories.

--- a/cli/classes/generated/windfile.py
+++ b/cli/classes/generated/windfile.py
@@ -18,8 +18,9 @@ class WindFile(BaseModel):
     api: definitions.Api
     metadata: definitions.WindfileMetadata
     environment: Optional[definitions.Environment] = None
-    jobs: Dict[constr(pattern=r'^[a-zA-Z0-9._-]+$'), definitions.Action] = Field(
+    repositories: Optional[Dict[constr(pattern=r'^[a-zA-Z0-9._-]+$'), definitions.Repository]] = None
+    actions: Dict[constr(pattern=r'^[a-zA-Z0-9._-]+$'), definitions.Action] = Field(
         ...,
         description='The actions that are executed during a CI job in a target system. When a job is executed, the actions are executed in the order they are defined in the windfile.',
-        title='Jobs',
+        title='Actions',
     )

--- a/cli/classes/generator.py
+++ b/cli/classes/generator.py
@@ -54,7 +54,7 @@ class Generator(PassSettings):
             logger.error("❌ ", "Merging failed. Aborting.", self.output_settings.emoji)
             return None
         # current_action: FileAction | InternalAction | PlatformAction |
-        # ExternalAction = self.windfile.jobs[
+        # ExternalAction = self.windfile.actions[
         #     "hello-world_0"
         # ].root
         # if not isinstance(current_action, InternalAction):

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -249,7 +249,7 @@ class Merger(PassSettings):
 
                 if converted and len(converted[0]) == 1:
                     # found no other way to do this
-                    self.windfile.jobs[name] = converted[1][0]  # type: ignore
+                    self.windfile.actions[name] = converted[1][0]  # type: ignore
                     self.metadata.append(
                         scope="actions",
                         key=name,
@@ -307,15 +307,15 @@ class Merger(PassSettings):
             )
 
             merge_environment(
-                self.windfile.jobs[name].root.environment,
+                self.windfile.actions[name].root.environment,
                 action,
             )
             merge_parameters(
-                self.windfile.jobs[name].root.parameters,
+                self.windfile.actions[name].root.parameters,
                 action,
             )
             merge_lifecycle(
-                self.windfile.jobs[name].root.excludeDuring,
+                self.windfile.actions[name].root.excludeDuring,
                 action,
             )
             logger.info(
@@ -330,8 +330,8 @@ class Merger(PassSettings):
                 value=name,
             )
 
-            self.windfile.jobs[new_name] = action
-        self.windfile.jobs.pop(name)
+            self.windfile.actions[new_name] = action
+        self.windfile.actions.pop(name)
         return None
 
     def convert_external_action_to_internal(

--- a/cli/classes/validator.py
+++ b/cli/classes/validator.py
@@ -29,8 +29,8 @@ def has_external_actions(windfile: WindFile) -> bool:
     :param windfile: input windfile
     :return: True if the windfile contains external actions, False otherwise
     """
-    for name in windfile.jobs:
-        action: Action = windfile.jobs[name]
+    for name in windfile.actions:
+        action: Action = windfile.actions[name]
         if isinstance(action.root, ExternalAction):
             return True
     return False
@@ -71,8 +71,8 @@ def get_actions_of_type(
     if not windfile:
         return []
     actions: typing.List[typing.Tuple[str, Action]] = []
-    for name in windfile.jobs:
-        action: typing.Any = windfile.jobs[name]
+    for name in windfile.actions:
+        action: typing.Any = windfile.actions[name]
         if "root" in action.__dict__:
             # this allows handling of manually created actions during merging
             action = action.root
@@ -112,8 +112,8 @@ def get_actions(
     :return: List of actions
     """
     actions: typing.List[InternalAction | ExternalAction | FileAction | PlatformAction] = []
-    for name in windfile.jobs:
-        action: Action = windfile.jobs[name]
+    for name in windfile.actions:
+        action: Action = windfile.actions[name]
         if isinstance(action.root, InternalAction):
             actions.append(action.root)
         elif isinstance(action.root, ExternalAction):
@@ -132,8 +132,8 @@ def get_internal_actions(windfile: WindFile) -> typing.List[InternalAction]:
     :return:
     """
     actions: typing.List[InternalAction] = []
-    for name in windfile.jobs:
-        action: Action = windfile.jobs[name]
+    for name in windfile.actions:
+        action: Action = windfile.actions[name]
         if isinstance(action.root, InternalAction):
             actions.append(action.root)
     return actions

--- a/cli/examples/windfiles/windfile-with-external-action.yml
+++ b/cli/examples/windfiles/windfile-with-external-action.yml
@@ -4,19 +4,16 @@ metadata:
   description: This is a windfile with an internal action
   author: Andreas Resch
   gitCredentials: artemis_gitlab_admin_credentials
-jobs:
-  clone:
-    use: clone-default
-    parameters:
-      repository: http://docker.for.mac.host.internal:8081/JENREF/jenref-tests.git
-      branch: main
-      path: .
-  clone-tests:
-    use: clone-default
-    parameters:
-      repository: http://docker.for.mac.host.internal:8081/JENREF/jenref-exercise.git
-      branch: main
-      path: assignments
+repositories:
+  tests:
+    url: http://docker.for.mac.host.internal:8081/JENREF/jenref-tests.git
+    branch: main
+    path: .
+  exercise:
+    url: http://docker.for.mac.host.internal:8081/JENREF/jenref-exercise.git
+    branch: main
+    path: assignment
+actions:
   internal-action:
     script: |
       echo "This is an internal action"

--- a/cli/examples/windfiles/windfile-with-file-action.yml
+++ b/cli/examples/windfiles/windfile-with-file-action.yml
@@ -3,7 +3,7 @@ metadata:
   name: windfile-with-internal-action
   description: This is a windfile with an external action
   author: Andreas Resch
-jobs:
+actions:
   first-job:
     file: ../actions/file-action.py
     parameters:

--- a/cli/examples/windfiles/windfile-with-internal-action.yml
+++ b/cli/examples/windfiles/windfile-with-internal-action.yml
@@ -3,9 +3,12 @@ metadata:
   name: windfile-with-internal-action
   description: This is a windfile with an internal action
   author: Andreas Resch
-jobs:
+actions:
   internal-action:
     script: |
       echo "Hello from an internal action"
     parameters:
       WHO: "me"
+  maven:
+    script: |
+      echo "mvn clean install"

--- a/cli/examples/windfiles/windfile-with-platform-action.yml
+++ b/cli/examples/windfiles/windfile-with-platform-action.yml
@@ -3,6 +3,6 @@ metadata:
   name: windfile-with-internal-action
   description: This is a windfile with a simple platform action
   author: Andreas Resch
-jobs:
+actions:
   hello-world:
     use: ../actions/platform-action.yml

--- a/cli/test/files/valid-windfile.yml
+++ b/cli/test/files/valid-windfile.yml
@@ -3,7 +3,7 @@ metadata:
   name: windfile-with-internal-action
   description: This is a windfile with an internal action
   author: Andreas Resch
-jobs:
+actions:
   internal-action:
     script: |
       echo "Hello from an internal action"

--- a/cli/test/files/windfile-with-external-action.yml
+++ b/cli/test/files/windfile-with-external-action.yml
@@ -3,7 +3,7 @@ metadata:
   name: windfile-with-internal-action
   description: This is a windfile with an external action
   author: Andreas Resch
-jobs:
+actions:
   first-job:
     file: ../actions/file-action.py
     parameters:

--- a/cli/test/files/windfile-with-file-action.yml
+++ b/cli/test/files/windfile-with-file-action.yml
@@ -3,7 +3,7 @@ metadata:
   name: windfile-with-internal-action
   description: This is a windfile with an external action
   author: Andreas Resch
-jobs:
+actions:
   first-job:
     file: ../actions/file-action.py
     parameters:

--- a/cli/test/test_merge.py
+++ b/cli/test/test_merge.py
@@ -42,11 +42,11 @@ class MergeTests(unittest.TestCase):
             self.assertIsNotNone(windfile)
             if windfile is None:
                 self.fail("Windfile is None")
-            self.assertEqual(len(windfile.jobs), 1)
-            self.assertTrue("internal-action" in windfile.jobs)
-            self.assertTrue(isinstance(windfile.jobs["internal-action"].root, InternalAction))
-            if isinstance(windfile.jobs["internal-action"].root, InternalAction):
-                action: InternalAction = windfile.jobs["internal-action"].root
+            self.assertEqual(len(windfile.actions), 1)
+            self.assertTrue("internal-action" in windfile.actions)
+            self.assertTrue(isinstance(windfile.actions["internal-action"].root, InternalAction))
+            if isinstance(windfile.actions["internal-action"].root, InternalAction):
+                action: InternalAction = windfile.actions["internal-action"].root
                 self.assertEqual(action.script, 'echo "This is an internal action"')
             else:
                 self.fail("Action is not an instance of InternalAction, but should be")
@@ -81,7 +81,7 @@ class MergeTests(unittest.TestCase):
               name: test windfile
               description: This is a windfile with no external actions
               author: Test Author
-            jobs:
+            actions:
                 external-action:
                     use: {action_file.name}
             """
@@ -96,7 +96,7 @@ class MergeTests(unittest.TestCase):
                 if windfile is None:
                     self.fail("Windfile is None")
                 self.assertIsNotNone(windfile)
-                self.assertEqual(len(windfile.jobs), 2)
+                self.assertEqual(len(windfile.actions), 2)
 
                 for name, action_content in [
                     ("external-action_0", 'echo "Hello from a simple action"'),
@@ -105,9 +105,9 @@ class MergeTests(unittest.TestCase):
                         'echo "Hello from the second step"\n',
                     ),
                 ]:
-                    self.assertTrue(name in windfile.jobs)
-                    self.assertTrue(isinstance(windfile.jobs[name].root, InternalAction))
-                    action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.jobs[name].root
+                    self.assertTrue(name in windfile.actions)
+                    self.assertTrue(isinstance(windfile.actions[name].root, InternalAction))
+                    action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.actions[name].root
                     if isinstance(action, InternalAction):
                         self.assertEqual(action.script, action_content)
                     else:
@@ -139,10 +139,10 @@ class MergeTests(unittest.TestCase):
                     os.unlink(bash_file.name)
                     self.fail("Windfile is None")
                 self.assertIsNotNone(windfile)
-                self.assertEqual(len(windfile.jobs), 1)
-                self.assertTrue("file-action" in windfile.jobs)
-                self.assertTrue(isinstance(windfile.jobs["file-action"].root, InternalAction))
-                action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.jobs[
+                self.assertEqual(len(windfile.actions), 1)
+                self.assertTrue("file-action" in windfile.actions)
+                self.assertTrue(isinstance(windfile.actions["file-action"].root, InternalAction))
+                action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.actions[
                     "file-action"
                 ].root
                 if isinstance(action, InternalAction):

--- a/cli/test/windfile_definitions.py
+++ b/cli/test/windfile_definitions.py
@@ -5,7 +5,7 @@ VALID_WINDFILE_INTERNAL_ACTION: str = """
           name: test windfile
           description: This is a windfile with no external actions
           author: Test Author
-        jobs:
+        actions:
           internal-action:
             script: echo "This is an internal action"
         """
@@ -15,7 +15,7 @@ INVALID_WINDFILE_INTERNAL_ACTION: str = """
           name: test windfile
           description: This is a windfile with no external actions
           author: Test Author
-        jobs:
+        actions:
           internal-action:
         script: echo "This is an internal action"
         """
@@ -25,7 +25,7 @@ VALID_WINDFILE_WITH_NON_EXISTING_ACTIONFILE: str = """
           name: test windfile
           description: This is a windfile with no external actions
           author: Test Author
-        jobs:
+        actions:
           invalid-action:
             use: ./this-file-does-not-exist.yaml
         """
@@ -35,7 +35,7 @@ VALID_WINDFILE_WITH_FILEACTION: str = """
           name: test windfile
           description: This is a windfile with no external actions
           author: Test Author
-        jobs:
+        actions:
           file-action:
             file: [FILE_ACTION_FILE]
             excludeDuring:

--- a/schemas/v0.0.1/examples/action.yaml
+++ b/schemas/v0.0.1/examples/action.yaml
@@ -12,7 +12,7 @@ steps:
   clone:
     file: clone-default.py
     parameters:
-      - name: url
+      name: url
   build:
     script: |
       cargo build

--- a/schemas/v0.0.1/schemas/definitions.json
+++ b/schemas/v0.0.1/schemas/definitions.json
@@ -397,5 +397,42 @@
       "username",
       "password"
     ]
+  },
+  "repository": {
+    "title": "Repository",
+    "description": "Repository to be checked out during the execution of the actions",
+    "type": "object",
+    "allowAdditionalProperties": false,
+    "properties": {
+      "url": {
+        "description": "The url of the repository",
+        "type": "string",
+        "examples": [
+          "https://github.com/ls1intum/Aeolus.git"
+        ]
+      },
+      "branch": {
+        "description": "The branch to check out",
+        "type": "string",
+        "examples": [
+          "main"
+        ],
+        "default": "main"
+      },
+      "path": {
+        "description": "The path where the content of the repository should be checked out",
+        "type": "string",
+        "examples": [
+          ".",
+          "tests"
+        ],
+        "default": "."
+      }
+    },
+    "required": [
+      "url",
+      "branch",
+      "path"
+    ]
   }
 }

--- a/schemas/v0.0.1/schemas/windfile.json
+++ b/schemas/v0.0.1/schemas/windfile.json
@@ -7,7 +7,7 @@
   "required": [
     "api",
     "metadata",
-    "jobs"
+    "actions"
   ],
   "properties": {
     "api": {
@@ -19,8 +19,15 @@
     "environment": {
       "$ref": "definitions.json#/environment"
     },
-    "jobs": {
-      "title": "Jobs",
+    "repositories": {
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "definitions.json#/repository"
+        }
+      }
+    },
+    "actions": {
+      "title": "Actions",
       "description": "The actions that are executed during a CI job in a target system. When a job is executed, the actions are executed in the order they are defined in the windfile.",
       "type": "object",
       "patternProperties": {


### PR DESCRIPTION
# why actions?

Well, we need a uniform nomenclature to make Aeolus easy to use, the first joice using `jobs` was unfortunate, so we switch to actions. Makes it simpler and aligned with the actionfiles that we already have.

# why repositories?
The handling of repositories is special for all our targets, especially Bamboo, so we now handle them completely differently. Makes the code generation more straightforward and highlights the difference between the actions and the repositories.