### PR TITLE
Translation from Bamboo with docker support

### DIFF
--- a/bamboo-generator/build.gradle.kts
+++ b/bamboo-generator/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     implementation("com.atlassian.bamboo:bamboo-specs:9.3.3")
     // https://mvnrepository.com/artifact/org.jsonschema2pojo/jsonschema2pojo-core
     implementation("org.jsonschema2pojo:jsonschema2pojo-core:1.2.1")
+    // https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp
+    implementation("com.squareup.okhttp3:okhttp:4.11.0")
+
 //    implementation("org.yaml:snakeyaml:2.2")
     implementation("com.google.code.gson:gson:2.10.1")
     testImplementation(platform("org.junit:junit-bom:5.9.1"))

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/Main.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/Main.java
@@ -14,10 +14,15 @@ import com.atlassian.bamboo.specs.builders.task.VcsCheckoutTask;
 import com.atlassian.bamboo.specs.util.BambooSpecSerializer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import de.tum.cit.ase.bamboo.BuildPlanService;
+import de.tum.cit.ase.bamboo.Publisher;
 import de.tum.cit.ase.classes.*;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 
@@ -27,11 +32,40 @@ public class Main {
     private static final String STDIN_ARGUMENT = "--stdin";
     private static final String JSON_ARGUMENT = "--json";
     private static final String BASE64_ARGUMENT = "--base64";
+    private static final String GET_YAML_ARGUMENT = "--get-yaml";
+    private static final String PUBLISH_ARGUMENT = "--publish";
+    private static final String BAMBOOSERVER_ARGUMENT = "--server";
+    private static final String BAMBOOTOKEN_ARGUMENT = "--token";
+
+    private static boolean publish = false;
+    private static String bambooUrl = "";
+    private static String bambooToken = "";
+
+    private static void parseCredentials(String[] args) {
+        if (!Arrays.asList(args).contains(BAMBOOSERVER_ARGUMENT) || !Arrays.asList(args).contains(BAMBOOTOKEN_ARGUMENT)) {
+            System.err.println("If you want to interact with Bamboo, you also have to provide a bamboo server url and a bamboo token");
+        }
+        bambooUrl = args[Arrays.asList(args).indexOf(BAMBOOSERVER_ARGUMENT) + 1];
+        bambooToken = args[Arrays.asList(args).indexOf(BAMBOOTOKEN_ARGUMENT) + 1];
+    }
+
+    private static void parsePublish(String[] args) {
+        if (Arrays.asList(args).contains(PUBLISH_ARGUMENT)) {
+            publish = true;
+            parseCredentials(args);
+        }
+    }
+
+    private static Mode getMode(String[] args) {
+        if (Arrays.asList(args).contains(GET_YAML_ARGUMENT)) {
+            return Mode.FETCH_YAML;
+        }
+        return Mode.GENERATION;
+    }
 
     private static WindFile getInput(String[] args) {
-        System.err.println("Starting generation");
         if (args.length < 1) {
-            System.err.println("Usage: java -jar bamboo-generator.jar " + FILE_INPUT_ARGUMENT + "|" + STDIN_ARGUMENT);
+            System.err.println("Usage: java -jar bamboo-generator.jar " + FILE_INPUT_ARGUMENT + "|" + STDIN_ARGUMENT + "|" + JSON_ARGUMENT + "|" + BASE64_ARGUMENT + "|" + GET_YAML_ARGUMENT + " [path|json|base64|buildplankey]" + "--publish --server <bamboo-server-url> --token <bamboo-token>");
             System.exit(1);
         }
         String source = args[0];
@@ -40,6 +74,7 @@ public class Main {
                 if (args.length < 2) {
                     System.err.println("If you use a file, you also have to provide a file path");
                 }
+                parseCredentials(args);
                 String filePath = args[1];
                 try {
                     return WindFile.fromFile(filePath);
@@ -50,6 +85,7 @@ public class Main {
             }
             case STDIN_ARGUMENT -> {
                 StringBuilder builder = new StringBuilder();
+                parseCredentials(args);
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
                     String line;
                     while ((line = reader.readLine()) != null) {
@@ -75,6 +111,7 @@ public class Main {
                 if (args.length < 2) {
                     System.err.println("If you use json, you also have to provide a json object");
                 }
+                parsePublish(args);
                 String json = args[1];
                 try {
                     return WindFile.fromJson(json);
@@ -88,6 +125,7 @@ public class Main {
                 if (args.length < 2) {
                     System.err.println("If you use base64, you also have to provide a json object encoded in base64");
                 }
+                parsePublish(args);
                 byte[] decoded = Base64.getDecoder().decode(args[1]);
                 String json = new String(decoded);
                 try {
@@ -103,9 +141,7 @@ public class Main {
         return null;
     }
 
-    public static void main(String[] args) {
-        // we support stdin as input and also filepaths, the default is stdin, a file
-        // can be passed if the first argument is --file
+    private static void generateBuildPlan(String[] args) {
 
         WindFile windFile = getInput(args);
 //        if (args.length == 2) {
@@ -138,7 +174,7 @@ public class Main {
                 continue;
             }
             InternalAction internalAction = (InternalAction) action;
-            var keyInput = internalAction.getName().toUpperCase().replaceAll("-", "") + stageList.size();
+            var keyInput = internalAction.getName().toUpperCase().replaceAll("-", "").replaceAll("_", "") + stageList.size();
             var key = new BambooKey(keyInput);
             var tasks = buildPlanService.handleAction(internalAction);
             Stage stage = new Stage(internalAction.getName()).jobs(
@@ -151,5 +187,26 @@ public class Main {
         final String yaml = BambooSpecSerializer.dump(plan);
         System.err.println("✅ Generation done, printing result to stdout");
         System.out.println(yaml);
+    }
+
+    private static void getYAML(String[] args) {
+        if (args.length < 2) {
+            System.err.println("If you use --get-yaml, you also have to provide a build plan key");
+        }
+        parseCredentials(args);
+        String buildPlanKey = args[Arrays.asList(args).indexOf(GET_YAML_ARGUMENT) + 1];
+        Publisher publisher = new Publisher(bambooUrl, bambooToken);
+        String planYAML = publisher.getPlanYAML(buildPlanKey);
+        System.out.println(planYAML);
+    }
+
+    public static void main(String[] args) {
+        // we support stdin as input and also filepaths, the default is stdin, a file
+        // can be passed if the first argument is --file
+        Mode mode = getMode(args);
+        switch (mode) {
+            case GENERATION -> generateBuildPlan(args);
+            case FETCH_YAML -> getYAML(args);
+        }
     }
 }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/Mode.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/Mode.java
@@ -1,0 +1,6 @@
+package de.tum.cit.ase;
+
+public enum Mode {
+    GENERATION,
+    FETCH_YAML
+}

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
@@ -36,19 +36,13 @@ public class BuildPlanService {
 
     public List<Task<?, ?>> handleSpecialAction(PlatformAction action) {
         var tasks = new ArrayList<Task<?, ?>>();
-        var envs = Arrays.stream(action.getEnvironment().entrySet().stream()
-                .map(entry -> entry.getKey() + "=" + entry.getValue())
-                .toArray(String[]::new)).reduce((a, b) -> a + ";" + b).orElse("");
-        var params = Arrays.stream(action.getParameters().entrySet().stream()
-                .map(entry -> entry.getKey() + "=" + entry.getValue())
-                .toArray(String[]::new)).reduce((a, b) -> a + ";" + b).orElse("");
 
         String type = action.getKind();
         switch (type) {
             case "junit": {
                 TestParserTask task = TestParserTask.createJUnitParserTask()
                         .description(action.getName())
-                        .resultDirectories(action.getParameters().get("test_results"));
+                        .resultDirectories(String.valueOf(action.getParameters().get("test_results")));
                 tasks.add(task);
                 break;
             }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
@@ -8,8 +8,6 @@ import com.atlassian.bamboo.specs.api.builders.repository.VcsChangeDetection;
 import com.atlassian.bamboo.specs.api.builders.task.Task;
 import com.atlassian.bamboo.specs.builders.repository.git.GitRepository;
 import com.atlassian.bamboo.specs.builders.task.ScriptTask;
-import com.atlassian.bamboo.specs.util.BambooServer;
-import com.atlassian.bamboo.specs.util.MapBuilder;
 import de.tum.cit.ase.classes.InternalAction;
 import de.tum.cit.ase.classes.Repository;
 

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
@@ -8,10 +8,16 @@ import com.atlassian.bamboo.specs.api.builders.repository.VcsChangeDetection;
 import com.atlassian.bamboo.specs.api.builders.task.Task;
 import com.atlassian.bamboo.specs.builders.repository.git.GitRepository;
 import com.atlassian.bamboo.specs.builders.task.ScriptTask;
+import com.atlassian.bamboo.specs.builders.task.TestParserTask;
+import com.atlassian.bamboo.specs.model.task.TestParserTaskProperties;
 import de.tum.cit.ase.classes.InternalAction;
+import de.tum.cit.ase.classes.PlatformAction;
 import de.tum.cit.ase.classes.Repository;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class BuildPlanService {
@@ -26,6 +32,28 @@ public class BuildPlanService {
                 .shallowClonesEnabled(true)
                 .remoteAgentCacheEnabled(false)
                 .changeDetection(new VcsChangeDetection());
+    }
+
+    public List<Task<?, ?>> handleSpecialAction(PlatformAction action) {
+        var tasks = new ArrayList<Task<?, ?>>();
+        var envs = Arrays.stream(action.getEnvironment().entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .toArray(String[]::new)).reduce((a, b) -> a + ";" + b).orElse("");
+        var params = Arrays.stream(action.getParameters().entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .toArray(String[]::new)).reduce((a, b) -> a + ";" + b).orElse("");
+
+        String type = action.getKind();
+        switch (type) {
+            case "junit": {
+                TestParserTask task = TestParserTask.createJUnitParserTask()
+                        .description(action.getName())
+                        .resultDirectories(action.getParameters().get("test_results"));
+                tasks.add(task);
+                break;
+            }
+        }
+        return tasks;
     }
 
     public List<Task<?, ?>> handleAction(InternalAction action) {
@@ -50,7 +78,7 @@ public class BuildPlanService {
             var condMap = new HashMap<String, String>();
             condMap.put("operation", "matches");
             condMap.put("variable", "lifecycle_stage");
-            var regex = action.getExcludeDuring().stream().map( stage -> "[^(" + stage + ")]").collect(Collectors.joining());
+            var regex = action.getExcludeDuring().stream().map(stage -> "[^(" + stage + ")]").collect(Collectors.joining());
             condMap.put("value", "^.*" + regex + ".*");
             var condition = new AnyTaskCondition(
                     new AtlassianModule(

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/Publisher.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/Publisher.java
@@ -1,0 +1,63 @@
+package de.tum.cit.ase.bamboo;
+
+import com.atlassian.bamboo.specs.api.builders.plan.Plan;
+import com.atlassian.bamboo.specs.util.BambooServer;
+import com.atlassian.bamboo.specs.util.SimpleTokenCredentials;
+import com.atlassian.bamboo.specs.util.TokenCredentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public class Publisher {
+
+    private final BambooServer bambooServer;
+    private final String bambooUrl;
+    private final String token;
+
+    public Publisher(String url, String token) {
+        this.bambooUrl = url;
+        this.token = token;
+        TokenCredentials tokenCredentials = new SimpleTokenCredentials(token);
+        bambooServer = new BambooServer(url, tokenCredentials);
+    }
+
+    public void publish(Plan plan) {
+        try {
+            bambooServer.publish(plan);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String getPlanYAML(String buildPlanKey) {
+        try {
+            OkHttpClient client = new OkHttpClient();
+
+            Request request = new Request.Builder()
+                    .url(bambooUrl + "/rest/api/latest/plan/" + buildPlanKey + "/specs?all&format=yaml")
+                    .header("Authorization", "Bearer " + token)
+                    .build();
+
+            Response response = client.newCall(request).execute();
+
+            String responseString = response.body().string();
+            DocumentBuilderFactory factory =
+                    DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            ByteArrayInputStream input = new ByteArrayInputStream(
+                    responseString.getBytes("UTF-8"));
+            Document doc = builder.parse(input);
+            return doc.getFirstChild().getFirstChild().getFirstChild().getTextContent();
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/Publisher.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/Publisher.java
@@ -15,6 +15,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class Publisher {
 
@@ -53,7 +54,7 @@ public class Publisher {
                     DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();
             ByteArrayInputStream input = new ByteArrayInputStream(
-                    responseString.getBytes("UTF-8"));
+                    responseString.getBytes(StandardCharsets.UTF_8));
             Document doc = builder.parse(input);
             return doc.getFirstChild().getFirstChild().getFirstChild().getTextContent();
         } catch (IOException | ParserConfigurationException | SAXException e) {

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/Action.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/Action.java
@@ -8,7 +8,7 @@ import java.util.Map;
 public abstract class Action {
 
     private String name;
-    private Map<String, String> parameters;
+    private Map<String, Object> parameters;
     private Map<String, String> environment;
     private List<String> excludeDuring;
     private DockerConfig docker;
@@ -32,11 +32,11 @@ public abstract class Action {
         this.name = name;
     }
 
-    public Map<String, String> getParameters() {
+    public Map<String, Object> getParameters() {
         return parameters;
     }
 
-    protected void setParameters(Map<String, String> parameters) {
+    protected void setParameters(Map<String, Object> parameters) {
         this.parameters = parameters;
     }
 

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/Action.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/Action.java
@@ -1,5 +1,7 @@
 package de.tum.cit.ase.classes;
 
+import com.atlassian.bamboo.specs.api.builders.docker.DockerConfiguration;
+
 import java.util.List;
 import java.util.Map;
 
@@ -9,9 +11,13 @@ public abstract class Action {
     private Map<String, String> parameters;
     private Map<String, String> environment;
     private List<String> excludeDuring;
+    private DockerConfig docker;
+    private boolean always;
 
     public static Action fromMap(String name, Map<String, Object> map) {
-        if (map.containsKey("script")) {
+        if (map.containsKey("kind")) {
+            return PlatformAction.fromMap(name, map);
+        } else if (map.containsKey("script")) {
             return InternalAction.fromMap(name, map);
         } else {
             return ExternalAction.fromMap(name, map);
@@ -48,5 +54,34 @@ public abstract class Action {
 
     protected void setExcludeDuring(List<String> excludeDuring) {
         this.excludeDuring = excludeDuring;
+    }
+
+    public boolean isAlways() {
+        return always;
+    }
+
+    protected void setAlways(boolean always) {
+        this.always = always;
+    }
+
+    public DockerConfig getDocker() {
+        return docker;
+    }
+
+    protected void setDocker(DockerConfig docker) {
+        this.docker = docker;
+    }
+
+    public DockerConfiguration convertDockerConfig() {
+        if (docker == null) {
+            return null;
+        }
+        DockerConfiguration configuration = new DockerConfiguration()
+                .image(docker.getImage() + ":" + docker.getTag())
+                .dockerRunArguments(docker.getParameters().toArray(new String[0]));
+        for (Map.Entry<String, String> entry : docker.getVolumes().entrySet()) {
+            configuration.volume(entry.getKey(), entry.getValue());
+        }
+        return configuration;
     }
 }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/DockerConfig.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/DockerConfig.java
@@ -1,0 +1,58 @@
+package de.tum.cit.ase.classes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DockerConfig {
+
+    private String image;
+    private String tag;
+    private Map<String, String> volumes;
+    private List<String> parameters;
+
+    public static DockerConfig fromMap(Map<String, Object> map) {
+        if (map == null || map.isEmpty()) {
+            return null;
+        }
+        DockerConfig dockerConfig = new DockerConfig();
+        dockerConfig.setImage((String) map.get("image"));
+        dockerConfig.setTag((String) map.getOrDefault("tag", "latest"));
+        dockerConfig.setVolumes((Map<String, String>) map.getOrDefault("volumes", new HashMap<>()));
+        dockerConfig.setParameters((List<String>) map.getOrDefault("parameters", new ArrayList<>()));
+        return dockerConfig;
+    }
+
+    private void setImage(String image) {
+        this.image = image;
+    }
+
+    private void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    private void setVolumes(Map<String, String> volumes) {
+        this.volumes = volumes;
+    }
+
+    private void setParameters(List<String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public Map<String, String> getVolumes() {
+        return volumes;
+    }
+
+    public List<String> getParameters() {
+        return parameters;
+    }
+}

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/DockerConfig.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/DockerConfig.java
@@ -19,7 +19,15 @@ public class DockerConfig {
         DockerConfig dockerConfig = new DockerConfig();
         dockerConfig.setImage((String) map.get("image"));
         dockerConfig.setTag((String) map.getOrDefault("tag", "latest"));
-        dockerConfig.setVolumes((Map<String, String>) map.getOrDefault("volumes", new HashMap<>()));
+        ArrayList<String> volumes = (ArrayList<String>) map.getOrDefault("volumes", new ArrayList<>());
+        HashMap<String, String> volumesMap = new HashMap<>();
+        for (String volume : volumes) {
+            String[] split = volume.split(":");
+            if (split.length == 2) {
+                volumesMap.put(split[0], split[1]);
+            }
+        }
+        dockerConfig.setVolumes(volumesMap);
         dockerConfig.setParameters((List<String>) map.getOrDefault("parameters", new ArrayList<>()));
         return dockerConfig;
     }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/DockerConfig.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/DockerConfig.java
@@ -32,35 +32,35 @@ public class DockerConfig {
         return dockerConfig;
     }
 
-    private void setImage(String image) {
-        this.image = image;
-    }
-
-    private void setTag(String tag) {
-        this.tag = tag;
-    }
-
-    private void setVolumes(Map<String, String> volumes) {
-        this.volumes = volumes;
-    }
-
-    private void setParameters(List<String> parameters) {
-        this.parameters = parameters;
-    }
-
     public String getImage() {
         return image;
+    }
+
+    private void setImage(String image) {
+        this.image = image;
     }
 
     public String getTag() {
         return tag;
     }
 
+    private void setTag(String tag) {
+        this.tag = tag;
+    }
+
     public Map<String, String> getVolumes() {
         return volumes;
     }
 
+    private void setVolumes(Map<String, String> volumes) {
+        this.volumes = volumes;
+    }
+
     public List<String> getParameters() {
         return parameters;
+    }
+
+    private void setParameters(List<String> parameters) {
+        this.parameters = parameters;
     }
 }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/ExternalAction.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/ExternalAction.java
@@ -13,7 +13,7 @@ public class ExternalAction extends Action {
         ExternalAction action = new ExternalAction();
         action.setName(name);
         action.setUse((String) map.get("use"));
-        action.setParameters((Map<String, String>) map.getOrDefault("parameters", new HashMap<>()));
+        action.setParameters((Map<String, Object>) map.getOrDefault("parameters", new HashMap<>()));
         action.setEnvironment((Map<String, String>) map.getOrDefault("environment", new HashMap<>()));
         action.setExcludeDuring((List<String>) map.getOrDefault("excludeDuring", new ArrayList<>()));
         action.setAlways((boolean) map.getOrDefault("always", false));

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/ExternalAction.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/ExternalAction.java
@@ -16,6 +16,8 @@ public class ExternalAction extends Action {
         action.setParameters((Map<String, String>) map.getOrDefault("parameters", new HashMap<>()));
         action.setEnvironment((Map<String, String>) map.getOrDefault("environment", new HashMap<>()));
         action.setExcludeDuring((List<String>) map.getOrDefault("excludeDuring", new ArrayList<>()));
+        action.setAlways((boolean) map.getOrDefault("always", false));
+        action.setDocker(DockerConfig.fromMap((Map<String, Object>) map.getOrDefault("docker", new HashMap<>())));
         return action;
     }
 

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/InternalAction.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/InternalAction.java
@@ -13,7 +13,7 @@ public class InternalAction extends Action {
         InternalAction action = new InternalAction();
         action.setName(name);
         action.setScript((String) map.get("script"));
-        action.setParameters((Map<String, String>) map.getOrDefault("parameters", new HashMap<>()));
+        action.setParameters((Map<String, Object>) map.getOrDefault("parameters", new HashMap<>()));
         action.setEnvironment((Map<String, String>) map.getOrDefault("environment", new HashMap<>()));
         action.setExcludeDuring((List<String>) map.getOrDefault("excludeDuring", new ArrayList<>()));
         action.setAlways((boolean) map.getOrDefault("always", false));

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/PlatformAction.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/PlatformAction.java
@@ -5,14 +5,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class InternalAction extends Action {
+public class PlatformAction extends Action {
 
-    private String script;
+    private String kind;
 
-    public static Action fromMap(String name, Map<String, Object> map) {
-        InternalAction action = new InternalAction();
+    public static PlatformAction fromMap(String name, Map<String, Object> map) {
+        PlatformAction action = new PlatformAction();
         action.setName(name);
-        action.setScript((String) map.get("script"));
+        action.setKind((String) map.get("kind"));
         action.setParameters((Map<String, String>) map.getOrDefault("parameters", new HashMap<>()));
         action.setEnvironment((Map<String, String>) map.getOrDefault("environment", new HashMap<>()));
         action.setExcludeDuring((List<String>) map.getOrDefault("excludeDuring", new ArrayList<>()));
@@ -21,11 +21,11 @@ public class InternalAction extends Action {
         return action;
     }
 
-    public String getScript() {
-        return script;
+    public String getKind() {
+        return kind;
     }
 
-    private void setScript(String script) {
-        this.script = script;
+    private void setKind(String kind) {
+        this.kind = kind;
     }
 }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/PlatformAction.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/PlatformAction.java
@@ -13,7 +13,7 @@ public class PlatformAction extends Action {
         PlatformAction action = new PlatformAction();
         action.setName(name);
         action.setKind((String) map.get("kind"));
-        action.setParameters((Map<String, String>) map.getOrDefault("parameters", new HashMap<>()));
+        action.setParameters((Map<String, Object>) map.getOrDefault("parameters", new HashMap<>()));
         action.setEnvironment((Map<String, String>) map.getOrDefault("environment", new HashMap<>()));
         action.setExcludeDuring((List<String>) map.getOrDefault("excludeDuring", new ArrayList<>()));
         action.setAlways((boolean) map.getOrDefault("always", false));

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFile.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFile.java
@@ -35,7 +35,7 @@ public class WindFile {
         windfile.setFilePath("stdin");
         windfile.setApi(data.get("api").toString());
         windfile.setMetadata(WindFileMetadata.fromMap((Map<String, Object>) data.get("metadata")));
-        Map<String, Object> repositories = (Map<String, Object>) data.get("repositories");
+        Map<String, Object> repositories = (Map<String, Object>) data.getOrDefault("repositories", new HashMap<String, Object>());
         for (Map.Entry<String, Object> repository : repositories.entrySet()) {
             Map<String, Object> repoMap = (Map<String, Object>) repository.getValue();
             windfile.appendRepository(Repository.fromMap(repository.getKey(), repoMap));

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFile.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFile.java
@@ -92,12 +92,12 @@ public class WindFile {
         return actions;
     }
 
-    public List<Repository> getRepositories() {
-        return repositories;
-    }
-
     public void setActions(List<Action> actions) {
         this.actions = actions;
+    }
+
+    public List<Repository> getRepositories() {
+        return repositories;
     }
 
     public void setRepositories(List<Repository> repositories) {

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFileMetadata.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFileMetadata.java
@@ -7,37 +7,50 @@ import java.util.Optional;
 public class WindFileMetadata {
 
     private String name;
+    private String id;
     private String description;
     private Author author;
     private DockerConfig docker;
     private Optional<String> gitCredentials;
 
+    public static WindFileMetadata fromMap(Map<String, Object> map) {
+        WindFileMetadata metadata = new WindFileMetadata();
+        metadata.setName((String) map.get("name"));
+        metadata.setDescription((String) map.get("description"));
+        Object author = map.get("author");
+        metadata.setAuthor(Author.fromObject(author));
+        metadata.setGitCredentials(Optional.ofNullable((String) map.get("gitCredentials")));
+        metadata.setId((String) map.get("id"));
+        metadata.setDocker(DockerConfig.fromMap((Map<String, Object>) map.getOrDefault("docker", null)));
+        return metadata;
+    }
+
     public String getName() {
         return name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public Author getAuthor() {
-        return author;
-    }
-
-    public Optional<String> getGitCredentials() {
-        return gitCredentials;
     }
 
     private void setName(String name) {
         this.name = name;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
     private void setDescription(String description) {
         this.description = description;
     }
 
+    public Author getAuthor() {
+        return author;
+    }
+
     private void setAuthor(Author author) {
         this.author = author;
+    }
+
+    public Optional<String> getGitCredentials() {
+        return gitCredentials;
     }
 
     private void setGitCredentials(Optional<String> gitCredentials) {
@@ -52,14 +65,29 @@ public class WindFileMetadata {
         this.docker = docker;
     }
 
-    public static WindFileMetadata fromMap(Map<String, Object> map) {
-        WindFileMetadata metadata = new WindFileMetadata();
-        metadata.setName((String) map.get("name"));
-        metadata.setDescription((String) map.get("description"));
-        Object author = map.get("author");
-        metadata.setAuthor(Author.fromObject(author));
-        metadata.setGitCredentials(Optional.ofNullable((String) map.get("gitCredentials")));
-        metadata.setDocker(DockerConfig.fromMap((Map<String, Object>) map.getOrDefault("docker", null)));
-        return metadata;
+    public String getId() {
+        return id;
+    }
+
+    private void setId(String id) {
+        this.id = id;
+    }
+
+    public String getProjectKey() {
+        String id = getId();
+        if (id.contains("/")) {
+            id = id.replaceAll("/", "-");
+        }
+        var parts = id.split("-");
+        return parts[0];
+    }
+
+    public String getPlanName() {
+        String id = getId();
+        if (id.contains("/")) {
+            id = id.replaceAll("/", "-");
+        }
+        var parts = id.split("-");
+        return parts[1];
     }
 }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFileMetadata.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFileMetadata.java
@@ -9,6 +9,7 @@ public class WindFileMetadata {
     private String name;
     private String description;
     private Author author;
+    private DockerConfig docker;
     private Optional<String> gitCredentials;
 
     public String getName() {
@@ -43,6 +44,14 @@ public class WindFileMetadata {
         this.gitCredentials = gitCredentials;
     }
 
+    public DockerConfig getDocker() {
+        return docker;
+    }
+
+    private void setDocker(DockerConfig docker) {
+        this.docker = docker;
+    }
+
     public static WindFileMetadata fromMap(Map<String, Object> map) {
         WindFileMetadata metadata = new WindFileMetadata();
         metadata.setName((String) map.get("name"));
@@ -50,6 +59,7 @@ public class WindFileMetadata {
         Object author = map.get("author");
         metadata.setAuthor(Author.fromObject(author));
         metadata.setGitCredentials(Optional.ofNullable((String) map.get("gitCredentials")));
+        metadata.setDocker(DockerConfig.fromMap((Map<String, Object>) map.getOrDefault("docker", null)));
         return metadata;
     }
 }

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -35,7 +35,7 @@ class BambooClient:
             return None
         condition: Optional[BambooCondition] = None
         for entry in conditions:
-            # TODO check if this behaves differently if there are more than one conditions
+            # check if this behaves differently if there are more than one conditions
             dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
             matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])
             variable: BambooConditionVariable = BambooConditionVariable(matches=matches["matches"])
@@ -96,7 +96,7 @@ class BambooClient:
         self,
         final_tasks: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
-        # TODO think about final tasks management in aeolus
+        # think about final tasks management in aeolus
         # for now, add them at the end
         tmp: list[dict[str, Any]] = final_tasks
         tasks: list[dict[str, Any]] = []

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -55,13 +55,8 @@ class BambooClient:
             ] = self.fix_keys(dictionary=task[task_type])
             if task_type == "script":
                 condition: Optional[BambooCondition] = None
-                if (
-                    "conditions" in task_dict
-                    and isinstance(task_dict["conditions"], list)
-                    and len(task_dict["conditions"]) > 0
-                    and isinstance(task_dict["conditions"][0], dict)
-                ):
-                    conditions: Optional[list[dict[str, Any]]] = task_dict.get("conditions", None)
+                conditions: Optional[int | bool | str | dict[str, Any] | list[str]] | list[dict[str, Any]] = task_dict.get("conditions", None)
+                if isinstance(conditions, list) and len(conditions) > 0 and isinstance(conditions[0], dict):
                     condition = self.parse_condition(conditions=conditions)
                 environment: dict[Any, str | float | None] = {}
                 if "environment" in task_dict:

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -129,10 +129,15 @@ class BambooClient:
                     # to make the creation of the BambooSpecs object easier
                     bamboo_docker = BambooDockerConfig(
                         image=str(job_dict["docker"]["image"]),
-                        volumes=job_dict["docker"]["volumes"] if isinstance(job_dict["docker"]["volumes"], dict) else {},
-                        docker_run_arguments=job_dict["docker"]["docker_run_arguments"] if isinstance(job_dict["docker"]["docker_run_arguments"], list) else [],
+                        volumes=job_dict["docker"]["volumes"]
+                        if isinstance(job_dict["docker"]["volumes"], dict)
+                        else {},
+                        docker_run_arguments=job_dict["docker"]["docker_run_arguments"]
+                        if isinstance(job_dict["docker"]["docker_run_arguments"], list)
+                        else [],
                     )
-                if "final_tasks" in job_dict:
+                if "final_tasks" in job_dict and isinstance(job_dict["final_tasks"], list)\
+                        and isinstance(job_dict["tasks"], list):
                     for final in self.handle_final_tasks(final_tasks=job_dict["final_tasks"]):
                         job_dict["tasks"].append(final)
                     del job_dict["final_tasks"]
@@ -167,8 +172,7 @@ class BambooClient:
                 element: Text = node
                 return element.data
             return None
-        else:
-            return self.extract_code(node=node.firstChild)
+        return self.extract_code(node=node.firstChild)
 
     def get_plan_yaml(self, plan_key: str) -> Optional[Tuple[BambooSpecs, dict[str, str]]]:
         """

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -34,8 +34,7 @@ class BambooClient:
         if conditions is None or (len(conditions) == 0 and isinstance(conditions[0], str)):
             return None
         condition: Optional[BambooCondition] = None
-        dictionary: list[dict[str, Any]] = conditions
-        for entry in dictionary:
+        for entry in conditions:
             # TODO check if this behaves differently if there are more than one conditions
             dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
             matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -45,7 +45,7 @@ class BambooClient:
                 if "conditions" not in task_dict:
                     task_dict["condition"] = None
                 else:
-                    if "conditions" in task_dict and isinstance(task_dict["conditions"], dict):
+                    if "conditions" in task_dict and isinstance(task_dict["conditions"], list):
                         for entry in task_dict["conditions"]:
                             # TODO check if this behaves differently if there are more than one conditions
                             dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
@@ -145,7 +145,7 @@ class BambooClient:
                 repo: dict[str, int | bool | str] = repo_dict[repo_name]
                 repo = self.fix_keys(dictionary=repo)
                 repositories[repo_name] = BambooRepository(
-                    type=str(repo["type"]),
+                    repo_type=str(repo["type"]),
                     url=str(repo["url"]),
                     branch=str(repo["branch"]),
                     shared_credentials=str(repo["shared_credentials"]),

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -25,16 +25,17 @@ class BambooClient:
     def __init__(self, credentials: BambooCredentials):
         self.credentials = credentials
 
-    def parse_condition(self, conditions: Optional[list[dict[str, Any]]]) -> Optional[BambooCondition]:
+    def parse_condition(self, conditions: Optional[list[str] | list[dict[str, Any]]]) -> Optional[BambooCondition]:
         """
         Parse a condition string into a BambooCondition object.
-        :param conditions: conditions from Bamboo Repsonse
+        :param conditions: conditions from Bamboo Response
         :return: BambooCondition object
         """
-        if conditions is None:
+        if conditions is None or (len(conditions) == 0 and isinstance(conditions[0], str)):
             return None
         condition: Optional[BambooCondition] = None
-        for entry in conditions:
+        dictionary: list[dict[str, Any]] = conditions
+        for entry in dictionary:
             # TODO check if this behaves differently if there are more than one conditions
             dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
             matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -4,7 +4,6 @@ from xml.dom.minidom import parseString, Document, Text, Node
 import requests
 import yaml
 
-from classes.bamboo_credentials import BambooCredentials
 from classes.bamboo_specs import (
     BambooSpecs,
     BambooPlan,
@@ -18,6 +17,7 @@ from classes.bamboo_specs import (
     BambooDockerConfig,
     BambooSpecialTask,
 )
+from classes.ci_credentials import CICredentials
 
 
 def handle_final_tasks(
@@ -64,7 +64,7 @@ class BambooClient:
     Client for the Bamboo REST API.
     """
 
-    credentials: BambooCredentials
+    credentials: CICredentials
 
     def __init__(self, credentials: BambooCredentials):
         self.credentials = credentials

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -138,7 +138,11 @@ class BambooClient:
                 if "other" not in job_dict:
                     job_dict["other"] = None
                 tasks_dict: Optional[list[dict[str, Any]]] = None
-                if isinstance(job_dict["tasks"], list) and len(job_dict["tasks"]) > 0 and isinstance(job_dict["tasks"][0], dict):
+                if (
+                    isinstance(job_dict["tasks"], list)
+                    and len(job_dict["tasks"]) > 0
+                    and isinstance(job_dict["tasks"][0], dict)
+                ):
                     tasks_dict = job_dict["tasks"]
                 if tasks_dict is None:
                     continue
@@ -156,14 +160,14 @@ class BambooClient:
             stages[stage_name] = stage
         return stages
 
-    def extract_code(self, node: Node) -> str:
+    def extract_code(self, node: Node) -> Optional[str]:
         if node.firstChild is None:
             if isinstance(node, Text):
                 element: Text = node
                 return element.data
+            return None
         else:
             return self.extract_code(node=node.firstChild)
-
 
     def get_plan_yaml(self, plan_key: str) -> Optional[Tuple[BambooSpecs, dict[str, str]]]:
         """

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -55,7 +55,9 @@ class BambooClient:
             ] = self.fix_keys(dictionary=task[task_type])
             if task_type == "script":
                 condition: Optional[BambooCondition] = None
-                conditions: Optional[int | bool | str | dict[str, Any] | list[str]] | list[dict[str, Any]] = task_dict.get("conditions", None)
+                conditions: Optional[int | bool | str | dict[str, Any] | list[str]] | list[
+                    dict[str, Any]
+                ] = task_dict.get("conditions", None)
                 if isinstance(conditions, list) and len(conditions) > 0 and isinstance(conditions[0], dict):
                     condition = self.parse_condition(conditions=conditions)
                 environment: dict[Any, str | float | None] = {}
@@ -131,8 +133,11 @@ class BambooClient:
                         if isinstance(job_dict["docker"]["docker_run_arguments"], list)
                         else [],
                     )
-                if "final_tasks" in job_dict and isinstance(job_dict["final_tasks"], list)\
-                        and isinstance(job_dict["tasks"], list):
+                if (
+                    "final_tasks" in job_dict
+                    and isinstance(job_dict["final_tasks"], list)
+                    and isinstance(job_dict["tasks"], list)
+                ):
                     for final in self.handle_final_tasks(final_tasks=job_dict["final_tasks"]):
                         job_dict["tasks"].append(final)
                     del job_dict["final_tasks"]

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -129,8 +129,8 @@ class BambooClient:
                     # to make the creation of the BambooSpecs object easier
                     bamboo_docker = BambooDockerConfig(
                         image=str(job_dict["docker"]["image"]),
-                        volumes=job_dict["docker"]["volumes"],
-                        docker_run_arguments=job_dict["docker"]["docker_run_arguments"],
+                        volumes=job_dict["docker"]["volumes"] if isinstance(job_dict["docker"]["volumes"], dict) else {},
+                        docker_run_arguments=job_dict["docker"]["docker_run_arguments"] if isinstance(job_dict["docker"]["docker_run_arguments"], list) else [],
                     )
                 if "final_tasks" in job_dict:
                     for final in self.handle_final_tasks(final_tasks=job_dict["final_tasks"]):

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -66,7 +66,7 @@ class BambooClient:
 
     credentials: CICredentials
 
-    def __init__(self, credentials: BambooCredentials):
+    def __init__(self, credentials: CICredentials):
         self.credentials = credentials
 
     def parse_condition(self, conditions: Optional[list[str] | list[dict[str, Any]]]) -> Optional[BambooCondition]:

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -55,17 +55,20 @@ class BambooClient:
                 if "scripts" in task_dict:
                     for script in task_dict["scripts"]:
                         scripts.append(str(script))
-                task = BambooTask(
+                tasks.append(BambooTask(
                     interpreter=str(task_dict["interpreter"]),
                     scripts=scripts,
                     environment=environment,
                     description=str(task_dict["description"]) if "description" in task_dict else "",
                     condition=condition,
-                )
-                tasks.append(task)
+                ))
             elif task_type == "checkout":
-                checkout: BambooCheckoutTask = BambooCheckoutTask(**task_dict)
-                tasks.append(checkout)
+                tasks.append(BambooCheckoutTask(
+                    repository=str(task_dict["repository"]),
+                    force_clean_build=bool(task_dict["force_clean_build"]),
+                    path=str(task_dict["path"]) if "path" in task_dict else "",
+                    description=str(task_dict["description"]) if "description" in task_dict else "",
+                ))
             else:
                 print(f"Task type {task_type} is not implemented")
                 # raise NotImplementedError(f"Task type {task_type} is not implemented")

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -55,7 +55,9 @@ class BambooClient:
                 dictionary=task[task_type]
             )
             if task_type == "script":
-                condition: Optional[BambooCondition] = self.parse_condition(conditions=task_dict.get("conditions", None))
+                condition: Optional[BambooCondition] = None
+                if "conditions" in task_dict and isinstance(task_dict["conditions"], list):
+                    condition = self.parse_condition(conditions=task_dict.get("conditions", None))
                 environment: dict[Any, str | float | None] = {}
                 if "environment" in task_dict:
                     for entry in str(task_dict["environment"]).split(";"):

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -1,0 +1,184 @@
+from typing import Optional, Tuple, Any
+from xml.dom.minidom import parseString, Document, Node
+
+import requests
+import yaml
+
+from classes.bamboo_specs import (
+    BambooSpecs,
+    BambooPlan,
+    BambooStage,
+    BambooRepository,
+    BambooJob,
+    BambooTask,
+    BambooCheckoutTask,
+    BambooCondition,
+    BambooConditionVariable,
+    BambooDockerConfig,
+)
+
+
+class BambooClient:
+    url: str = ""
+    token: str = ""
+
+    def __init__(self, url: str, token: str):
+        self.url = url
+        self.token = token
+
+    def handle_tasks(self, job_dict: list[dict[str, Any]]) -> list[BambooTask | BambooCheckoutTask]:
+        tasks: list[BambooTask | BambooCheckoutTask] = []
+        for task in job_dict:
+            task = self.fix_keys(dictionary=task)
+            task_type: str = list(task.keys())[0]
+            task_dict: dict[str, Optional[int | bool | str | dict[str, Any]]] = self.fix_keys(
+                dictionary=task[task_type]
+            )
+            if task_type == "script":
+                condition: Optional[BambooCondition] = None
+                environment: dict[str, str] = {}
+                if "environment" in task_dict:
+                    for entry in str(task_dict["environment"]).split(";"):
+                        key, value = entry.split("=")
+                        environment[key] = value
+                task_dict["environment"] = None
+                if "conditions" not in task_dict:
+                    task_dict["condition"] = None
+                else:
+                    for entry in task_dict["conditions"]:
+                        # TODO check if this behaves differently if there are more than one conditions
+                        dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
+                        matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])
+                        variable: BambooConditionVariable = BambooConditionVariable(matches=matches["matches"])
+                        if condition is None:
+                            condition: BambooCondition = BambooCondition(variables=[variable])
+                        else:
+                            condition.variables.append(variable)
+                        del task_dict["conditions"]
+                        task_dict["condition"] = None
+                task = BambooTask(**task_dict)
+                task.condition = condition
+                task.environment = environment
+                tasks.append(task)
+            elif task_type == "checkout":
+                checkout: BambooCheckoutTask = BambooCheckoutTask(**task_dict)
+                tasks.append(checkout)
+            else:
+                print(f"Task type {task_type} is not implemented")
+                # raise NotImplementedError(f"Task type {task_type} is not implemented")
+        return tasks
+
+    def handle_final_tasks(
+        self,
+        final_tasks: list[dict[str, Any]],
+    ):
+        # TODO think about final tasks management in aeolus
+        # for now, add them at the end
+        tmp: list[dict[str, Any]] = final_tasks
+        tasks: list[dict[str, Any]] = []
+        for item in tmp:
+            old_key: str = list(item.keys())[0]
+            task_type: str = item[old_key]["type"] if "type" in item[old_key] else old_key
+            if "type" in item[old_key]:
+                del item[old_key]["type"]
+            tasks.append({task_type: item[old_key]})
+        return tasks
+
+    def convert_stages(self, plan_specs: dict[str, Any]) -> dict[str, BambooStage]:
+        stages: dict[str, BambooStage] = {}
+        dictionary: list[dict[str, Any]] = plan_specs["stages"]
+
+        for stage_dict in dictionary:
+            stage_name = list(stage_dict.keys())[0]
+            job_list: list[str] = stage_dict[stage_name]["jobs"]
+            stage_dict[stage_name]["jobs"] = {}
+            stage: BambooStage = BambooStage(**stage_dict[stage_name])
+            for job_name in job_list:
+                job_dict: dict[str, Optional[int | bool | str | dict[str, Any] | list[Any]]] = plan_specs[job_name]
+                job_dict = self.fix_keys(dictionary=job_dict)
+                if "docker" in job_dict:
+                    # we handle docker "tasks" differently (in the metadata rather then a job), so we remove them here
+                    # to make the creation of the BambooSpecs object easier
+                    docker_config: dict[str, Any] = self.fix_keys(job_dict["docker"])
+                    job_dict["docker"] = BambooDockerConfig(**docker_config)
+                else:
+                    job_dict["docker"] = None
+                if "final_tasks" in job_dict:
+                    for final in self.handle_final_tasks(final_tasks=job_dict["final_tasks"]):
+                        job_dict["tasks"].append(final)
+                    del job_dict["final_tasks"]
+                if "other" not in job_dict:
+                    job_dict["other"] = None
+                job: BambooJob = BambooJob(**job_dict)
+                tasks: list[BambooTask] = self.handle_tasks(job_dict=job_dict["tasks"])
+                job.tasks = tasks
+                stage.jobs[job_name] = job
+            stages[stage_name] = stage
+        return stages
+
+    def get_plan_yaml(self, plan_key: str) -> Optional[Tuple[BambooSpecs, dict[str, str]]]:
+        """
+        Get the YAML representation of the given plan by using the REST API.
+        :param plan_key:
+        :return: YAML representation of the plan
+        """
+        auth: dict = {"Authorization": f"Bearer {self.token}"}
+        response = requests.get(
+            f"{self.url}/rest/api/latest/plan/{plan_key}/specs?all", params={"format": "yaml"}, headers=auth
+        )
+        if response.status_code != 200:
+            return None
+        document: Document = parseString(response.text)
+        code_node: Node | None = document.firstChild.firstChild.firstChild
+        if code_node is not None and code_node.firstChild is not None:
+            code: str = code_node.firstChild.nodeValue
+
+            specs: str = code.split("\n---\n")[0]
+            # permissions: str = code.split("\n---\n")[1]
+            dictionary: dict[str, Any] = yaml.safe_load(specs)
+            dictionary["plan"] = self.fix_keys(dictionary=dictionary["plan"])
+            stages: dict[str, BambooStage] = self.convert_stages(plan_specs=dictionary)
+            repositories: dict[str, BambooRepository] = {}
+            for repo_dict in dictionary["repositories"]:
+                repo_name = list(repo_dict.keys())[0]
+                repo: dict[str, int | bool | str] = repo_dict[repo_name]
+                repo = self.fix_keys(dictionary=repo)
+                repositories[repo_name] = BambooRepository(
+                    type=str(repo["type"]),
+                    url=str(repo["url"]),
+                    branch=str(repo["branch"]),
+                    shared_credentials=str(repo["shared_credentials"]),
+                    command_timeout_minutes=str(repo["command_timeout_minutes"]),
+                    lfs=bool(repo["lfs"]),
+                    verbose_logs=bool(repo["verbose_logs"]),
+                    use_shallow_clones=bool(repo["use_shallow_clones"]),
+                    cache_on_agents=bool(repo["cache_on_agents"]),
+                    submodules=bool(repo["submodules"]),
+                    ssh_key_applies_to_submodules=bool(repo["ssh_key_applies_to_submodules"]),
+                    fetch_all=bool(repo["fetch_all"]),
+                )
+            sanitized: dict = {
+                "version": dictionary["version"],
+                "plan": BambooPlan(**dictionary["plan"]),
+                "stages": stages,
+                "variables": dictionary["variables"] if "variables" in dictionary else {},
+                "triggers": dictionary["triggers"],
+                "repositories": repositories,
+            }
+            bamboo_specs: BambooSpecs = BambooSpecs(**sanitized)
+            return bamboo_specs, yaml.safe_load(specs)
+        return None
+
+    def fix_keys(self, dictionary: dict[str, Any]) -> dict[str, Any]:
+        """
+        Replace all "-" in keys with "_"
+        :param dictionary to fix
+        :return: dictionary with fixed keys
+        """
+        clean: dict[str, Any] = {}
+        for key in dictionary.keys():
+            if "-" in key:
+                clean[key.replace("-", "_")] = dictionary[key]
+            else:
+                clean[key] = dictionary[key]
+        return clean

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -1,5 +1,5 @@
 from typing import Optional, Tuple, Any
-from xml.dom.minidom import parseString, Document, Node
+from xml.dom.minidom import parseString, Document, Node, Element
 
 import requests
 import yaml
@@ -155,7 +155,7 @@ class BambooClient:
         if response.status_code != 200:
             return None
         document: Document = parseString(response.text)
-        code_node: Node | None = document.firstChild.firstChild.firstChild
+        code_node: Element | None = document.firstChild.firstChild.firstChild
         if code_node is not None and code_node.firstChild is not None:
             code: str = code_node.firstChild.nodeValue
 

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -31,18 +31,19 @@ class BambooClient:
         :param conditions: conditions from Bamboo Response
         :return: BambooCondition object
         """
-        if conditions is None or (len(conditions) == 0 and isinstance(conditions[0], str)):
+        if conditions is None:
             return None
         condition: Optional[BambooCondition] = None
         for entry in conditions:
             # check if this behaves differently if there are more than one conditions
-            dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
-            matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])
-            variable: BambooConditionVariable = BambooConditionVariable(matches=matches["matches"])
-            if condition is None:
-                condition = BambooCondition(variables=[variable])
-            else:
-                condition.variables.append(variable)
+            if isinstance(entry, dict):
+                dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
+                matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])
+                variable: BambooConditionVariable = BambooConditionVariable(matches=matches["matches"])
+                if condition is None:
+                    condition = BambooCondition(variables=[variable])
+                else:
+                    condition.variables.append(variable)
         return condition
 
     def handle_tasks(self, job_dict: list[dict[str, Any]]) -> list[BambooTask | BambooCheckoutTask]:

--- a/cli/classes/bamboo_client.py
+++ b/cli/classes/bamboo_client.py
@@ -45,17 +45,18 @@ class BambooClient:
                 if "conditions" not in task_dict:
                     task_dict["condition"] = None
                 else:
-                    for entry in task_dict["conditions"]:
-                        # TODO check if this behaves differently if there are more than one conditions
-                        dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
-                        matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])
-                        variable: BambooConditionVariable = BambooConditionVariable(matches=matches["matches"])
-                        if condition is None:
-                            condition: BambooCondition = BambooCondition(variables=[variable])
-                        else:
-                            condition.variables.append(variable)
-                        del task_dict["conditions"]
-                        task_dict["condition"] = None
+                    if "conditions" in task_dict and isinstance(task_dict["conditions"], dict):
+                        for entry in task_dict["conditions"]:
+                            # TODO check if this behaves differently if there are more than one conditions
+                            dictionary: dict[str, dict[str, str]] = self.fix_keys(dictionary=entry)
+                            matches: dict[str, dict[str, str]] = self.fix_keys(dictionary=dictionary["variable"])
+                            variable: BambooConditionVariable = BambooConditionVariable(matches=matches["matches"])
+                            if condition is None:
+                                condition: BambooCondition = BambooCondition(variables=[variable])
+                            else:
+                                condition.variables.append(variable)
+                            del task_dict["conditions"]
+                            task_dict["condition"] = None
                 task = BambooTask(**task_dict)
                 task.condition = condition
                 task.environment = environment

--- a/cli/classes/bamboo_credentials.py
+++ b/cli/classes/bamboo_credentials.py
@@ -1,7 +1,0 @@
-class BambooCredentials:
-    def __init__(self, url: str, token: str):
-        self.url = url
-        self.token = token
-
-    url: str
-    token: str

--- a/cli/classes/bamboo_credentials.py
+++ b/cli/classes/bamboo_credentials.py
@@ -1,0 +1,7 @@
+class BambooCredentials:
+    def __init__(self, url: str, token: str):
+        self.url = url
+        self.token = token
+
+    url: str
+    token: str

--- a/cli/classes/bamboo_specs.py
+++ b/cli/classes/bamboo_specs.py
@@ -4,6 +4,10 @@ from typing import Optional, Any
 
 
 class BambooPlan:
+    """
+    BambooPlan represents a Bamboo plan as returned by the Bamboo REST API.
+    """
+
     def __init__(self, project_key: str, key: str, name: str, description: str) -> None:
         self.project_key = project_key
         self.key = key
@@ -17,6 +21,10 @@ class BambooPlan:
 
 
 class BambooCheckoutTask:
+    """
+    BambooCheckoutTask represents a Bamboo checkout task as returned by the Bamboo REST API.
+    """
+
     def __init__(
         self, repository: str, force_clean_build: bool, path: Optional[str] = None, description: Optional[str] = None
     ) -> None:
@@ -32,6 +40,10 @@ class BambooCheckoutTask:
 
 
 class BambooConditionVariable:
+    """
+    BambooConditionVariable represents a Bamboo condition variable as returned by the Bamboo REST API.
+    """
+
     def __init__(self, matches: dict[str, str]) -> None:
         self.matches = matches
 
@@ -39,6 +51,10 @@ class BambooConditionVariable:
 
 
 class BambooCondition:
+    """
+    BambooCondition represents a Bamboo condition as returned by the Bamboo REST API.
+    """
+
     def __init__(self, variables: list[BambooConditionVariable]) -> None:
         self.variables = variables
 
@@ -46,6 +62,10 @@ class BambooCondition:
 
 
 class BambooTask:
+    """
+    BambooTask represents a Bamboo task as returned by the Bamboo REST API.
+    """
+
     def __init__(
         self,
         interpreter: str,
@@ -53,21 +73,59 @@ class BambooTask:
         environment: dict[Any, str | float | None],
         description: str,
         condition: Optional[BambooCondition],
+        always_execute: bool = False,
     ) -> None:
         self.interpreter = interpreter
         self.scripts = scripts
         self.environment = environment
         self.description = description
         self.condition = condition
+        self.always_execute = always_execute
 
     interpreter: str
     scripts: list[str]
     environment: dict[Any, str | float | None]
     description: str
     condition: Optional[BambooCondition]
+    always_execute: bool
+
+
+class BambooSpecialTask(BambooTask):
+    """
+    SpecialBambooTask represents a special Bamboo task as returned by the Bamboo REST API.
+    """
+
+    def __init__(
+        self,
+        interpreter: str,
+        scripts: list[str],
+        parameters: dict[Any, int | str | float | bool | None],
+        environment: dict[Any, int | str | float | bool | None],
+        description: str,
+        condition: Optional[BambooCondition],
+        always_execute: bool,
+        task_type: str,
+    ) -> None:
+        super().__init__(
+            interpreter=interpreter,
+            scripts=scripts,
+            environment=environment,
+            description=description,
+            condition=condition,
+            always_execute=always_execute,
+        )
+        self.task_type = task_type
+        self.parameters = parameters
+
+    parameters: dict[Any, str | float | bool | None]
+    task_type: str
 
 
 class BambooDockerConfig:
+    """
+    BambooDockerConfig represents the docker configuration of a Bamboo job as returned by the Bamboo REST API.
+    """
+
     def __init__(self, image: str, volumes: dict[str, str], docker_run_arguments: list[str]) -> None:
         self.image = image
         self.volumes = volumes
@@ -79,10 +137,14 @@ class BambooDockerConfig:
 
 
 class BambooJob:
+    """
+    BambooJob represents a Bamboo job as returned by the Bamboo REST API.
+    """
+
     def __init__(
         self,
         key: str,
-        tasks: list[BambooCheckoutTask | BambooTask],
+        tasks: list[BambooCheckoutTask | BambooTask | BambooSpecialTask],
         artifact_subscriptions: list[Any],
         docker: Optional[BambooDockerConfig],
         other: Optional[dict[str, Any]],
@@ -101,6 +163,10 @@ class BambooJob:
 
 
 class BambooStage:
+    """
+    BambooStage represents a Bamboo stage as returned by the Bamboo REST API.
+    """
+
     def __init__(self, manual: bool, final: bool, jobs: dict[str, BambooJob]) -> None:
         self.manual = manual
         self.final = final
@@ -112,6 +178,10 @@ class BambooStage:
 
 
 class BambooRepository:
+    """
+    BambooRepository represents a Bamboo repository as returned by the Bamboo REST API.
+    """
+
     def __init__(
         self,
         repo_type: str,
@@ -155,6 +225,10 @@ class BambooRepository:
 
 
 class BambooSpecs:
+    """
+    BambooSpecs represents the specs of a Bamboo plan as returned by the Bamboo REST API.
+    """
+
     def __init__(
         self,
         version: int,

--- a/cli/classes/bamboo_specs.py
+++ b/cli/classes/bamboo_specs.py
@@ -114,7 +114,7 @@ class BambooStage:
 class BambooRepository:
     def __init__(
         self,
-        type: str,
+        repo_type: str,
         url: str,
         branch: str,
         shared_credentials: str,
@@ -127,7 +127,7 @@ class BambooRepository:
         ssh_key_applies_to_submodules: bool,
         fetch_all: bool,
     ) -> None:
-        self.type = type
+        self.repo_type = repo_type
         self.url = url
         self.branch = branch
         self.shared_credentials = shared_credentials
@@ -140,7 +140,7 @@ class BambooRepository:
         self.ssh_key_applies_to_submodules = ssh_key_applies_to_submodules
         self.fetch_all = fetch_all
 
-    type: str
+    repo_type: str
     url: str
     branch: str
     shared_credentials: str

--- a/cli/classes/bamboo_specs.py
+++ b/cli/classes/bamboo_specs.py
@@ -101,7 +101,7 @@ class BambooJob:
 
 
 class BambooStage:
-    def __init__(self, manual: bool, final: bool, jobs: list[BambooJob]) -> None:
+    def __init__(self, manual: bool, final: bool, jobs: dict[str, BambooJob]) -> None:
         self.manual = manual
         self.final = final
         self.jobs = jobs

--- a/cli/classes/bamboo_specs.py
+++ b/cli/classes/bamboo_specs.py
@@ -1,0 +1,180 @@
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-instance-attributes
+from typing import Optional, Any
+
+
+class BambooPlan:
+    def __init__(self, project_key: str, key: str, name: str, description: str) -> None:
+        self.project_key = project_key
+        self.key = key
+        self.name = name
+        self.description = description
+
+    project_key: str
+    key: str
+    name: str
+    description: str
+
+
+class BambooCheckoutTask:
+    def __init__(
+        self, repository: str, force_clean_build: bool, path: Optional[str] = None, description: Optional[str] = None
+    ) -> None:
+        self.repository = repository
+        self.force_clean_build = force_clean_build
+        self.path = path if path is not None else "."
+        self.description = description
+
+    repository: str
+    path: str
+    force_clean_build: bool
+    description: Optional[str]
+
+
+class BambooConditionVariable:
+    def __init__(self, matches: dict[str, str]) -> None:
+        self.matches = matches
+
+    matches: dict[str, str]
+
+
+class BambooCondition:
+    def __init__(self, variables: list[BambooConditionVariable]) -> None:
+        self.variables = variables
+
+    variables: list[BambooConditionVariable]
+
+
+class BambooTask:
+    def __init__(
+        self,
+        interpreter: str,
+        scripts: list[str],
+        environment: dict[Any, str | float | None],
+        description: str,
+        condition: Optional[BambooCondition],
+    ) -> None:
+        self.interpreter = interpreter
+        self.scripts = scripts
+        self.environment = environment
+        self.description = description
+        self.condition = condition
+
+    interpreter: str
+    scripts: list[str]
+    environment: dict[Any, str | float | None]
+    description: str
+    condition: Optional[BambooCondition]
+
+
+class BambooDockerConfig:
+    def __init__(self, image: str, volumes: dict[str, str], docker_run_arguments: list[str]) -> None:
+        self.image = image
+        self.volumes = volumes
+        self.docker_run_arguments = docker_run_arguments
+
+    image: str
+    volumes: dict[str, str]
+    docker_run_arguments: list[str]
+
+
+class BambooJob:
+    def __init__(
+        self,
+        key: str,
+        tasks: list[BambooCheckoutTask | BambooTask],
+        artifact_subscriptions: list[Any],
+        docker: Optional[BambooDockerConfig],
+        other: Optional[dict[str, Any]],
+    ) -> None:
+        self.key = key
+        self.tasks = tasks
+        self.artifact_subscriptions = artifact_subscriptions
+        self.docker = docker
+        self.other = other
+
+    key: str
+    tasks: list[BambooCheckoutTask | BambooTask]
+    artifact_subscriptions: list[Any]
+    docker: Optional[BambooDockerConfig]
+    other: Optional[dict[str, Any]]
+
+
+class BambooStage:
+    def __init__(self, manual: bool, final: bool, jobs: list[BambooJob]) -> None:
+        self.manual = manual
+        self.final = final
+        self.jobs = jobs
+
+    manual: bool
+    final: bool
+    jobs: dict[str, BambooJob]
+
+
+class BambooRepository:
+    def __init__(
+        self,
+        type: str,
+        url: str,
+        branch: str,
+        shared_credentials: str,
+        command_timeout_minutes: str,
+        lfs: bool,
+        verbose_logs: bool,
+        use_shallow_clones: bool,
+        cache_on_agents: bool,
+        submodules: bool,
+        ssh_key_applies_to_submodules: bool,
+        fetch_all: bool,
+    ) -> None:
+        self.type = type
+        self.url = url
+        self.branch = branch
+        self.shared_credentials = shared_credentials
+        self.command_timeout_minutes = command_timeout_minutes
+        self.lfs = lfs
+        self.verbose_logs = verbose_logs
+        self.use_shallow_clones = use_shallow_clones
+        self.cache_on_agents = cache_on_agents
+        self.submodules = submodules
+        self.ssh_key_applies_to_submodules = ssh_key_applies_to_submodules
+        self.fetch_all = fetch_all
+
+    type: str
+    url: str
+    branch: str
+    shared_credentials: str
+    command_timout_minutes: str
+    lfs: bool
+    verbose_logs: bool
+    use_shallow_clones: bool
+    cache_on_agents: bool
+    submodules: bool
+    ssh_key_applies_to_submodules: bool
+    fetch_all: bool
+
+
+class BambooSpecs:
+    def __init__(
+        self,
+        version: int,
+        plan: BambooPlan,
+        stages: dict[str, BambooStage],
+        variables: dict[str, str],
+        triggers: list[Any],
+        repositories: dict[str, BambooRepository],
+    ) -> None:
+        super().__init__()
+        self.version = version
+        self.plan = plan
+        self.stages = stages
+        self.variables = variables
+        self.triggers = triggers
+        self.repositories = repositories
+
+    version: int
+    plan: BambooPlan
+    stages: dict[str, BambooStage]
+    variables: dict[str, str]
+    triggers: list[Any]
+    repositories: dict[str, BambooRepository]

--- a/cli/classes/ci_credentials.py
+++ b/cli/classes/ci_credentials.py
@@ -2,6 +2,7 @@ class CICredentials:
     """
     Class to store CI credentials
     """
+
     def __init__(self, url: str, token: str):
         self.url = url
         self.token = token

--- a/cli/classes/ci_credentials.py
+++ b/cli/classes/ci_credentials.py
@@ -1,0 +1,10 @@
+class CICredentials:
+    """
+    Class to store CI credentials
+    """
+    def __init__(self, url: str, token: str):
+        self.url = url
+        self.token = token
+
+    url: str
+    token: str

--- a/cli/classes/generated/definitions.py
+++ b/cli/classes/generated/definitions.py
@@ -219,6 +219,9 @@ class ExternalAction(BaseModel):
         description="The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
     )
     docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
+    always: Optional[bool] = Field(
+        False, description='If this is set to true, the action is always executed, even if other actions fail.'
+    )
 
 
 class ActionMetadata(BaseModel):

--- a/cli/classes/generated/definitions.py
+++ b/cli/classes/generated/definitions.py
@@ -18,7 +18,7 @@ class Api(RootModel):
 
 
 class Dictionary(RootModel):
-    root: Dict[constr(pattern=r'.+'), Optional[Union[str, float]]]
+    root: Dict[constr(pattern=r'.+'), Optional[Union[str, float, bool]]]
 
 
 class Docker(BaseModel):

--- a/cli/classes/generated/definitions.py
+++ b/cli/classes/generated/definitions.py
@@ -21,6 +21,21 @@ class Dictionary(RootModel):
     root: Dict[constr(pattern=r'.+'), Optional[Union[str, float]]]
 
 
+class Docker(BaseModel):
+    """
+    Docker configuration that is used to execute the actions
+    """
+
+    image: str = Field(..., description='The docker image that is used to execute the action', examples=['rust:latest'])
+    tag: Optional[str] = Field(
+        'latest', description='The tag of the docker image that is used to execute the action', examples=['latest']
+    )
+    volumes: Optional[List[str]] = Field(None, description='The volumes that are mounted into the docker container')
+    parameters: Optional[List[str]] = Field(
+        None, description='The parameters that are passed to the docker daemon, e.g. --cpus=2'
+    )
+
+
 class Lifecycle(Enum):
     """
     Defines a part of the lifecycle of a job.
@@ -101,6 +116,7 @@ class FileAction(BaseModel):
         None,
         description="The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
     )
+    docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
 
 
 class InternalAction(BaseModel):
@@ -123,6 +139,7 @@ class InternalAction(BaseModel):
         None,
         description="The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
     )
+    docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
 
 
 class PlatformAction(BaseModel):
@@ -146,6 +163,7 @@ class PlatformAction(BaseModel):
     )
     environment: Optional[Environment] = Field(None, description='Environment variables for this platform action.')
     platform: Optional[Target] = Field(None, description='Ignored for this action.')
+    docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
 
 
 class Author(RootModel):
@@ -168,6 +186,7 @@ class WindfileMetadata(BaseModel):
     gitCredentials: Optional[Union[str, GitCredentials]] = Field(
         None, description='The git credentials that are used to clone the repositories'
     )
+    docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the actions')
 
 
 class ExternalAction(BaseModel):
@@ -190,6 +209,7 @@ class ExternalAction(BaseModel):
         None,
         description="The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
     )
+    docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
 
 
 class ActionMetadata(BaseModel):

--- a/cli/classes/generated/definitions.py
+++ b/cli/classes/generated/definitions.py
@@ -185,6 +185,11 @@ class WindfileMetadata(BaseModel):
     """
 
     name: str = Field(..., description='The name of the windfile.', examples=['rust-exercise-jobs'])
+    id: Optional[str] = Field(
+        None,
+        description='The id of the resulting job in the CI system.',
+        examples=['rust-exercise-jobs', 'AEOLUS-BASE', 'jenkins/job/path'],
+    )
     description: str = Field(
         ...,
         description='Description of what this list of actions is supposed to achieve',

--- a/cli/classes/generated/definitions.py
+++ b/cli/classes/generated/definitions.py
@@ -117,6 +117,9 @@ class FileAction(BaseModel):
         description="The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
     )
     docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
+    always: Optional[bool] = Field(
+        False, description='If this is set to true, the action is always executed, even if other actions fail.'
+    )
 
 
 class InternalAction(BaseModel):
@@ -140,6 +143,9 @@ class InternalAction(BaseModel):
         description="The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
     )
     docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
+    always: Optional[bool] = Field(
+        False, description='If this is set to true, the action is always executed, even if other actions fail.'
+    )
 
 
 class PlatformAction(BaseModel):
@@ -150,8 +156,7 @@ class PlatformAction(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    for_: Target = Field(..., alias='for', description='The platform that this action is defined for.')
-    file: str = Field(..., description='The file of the platform action. Written in Python')
+    file: Optional[str] = Field(None, description='The file of the platform action. Written in Python')
     parameters: Optional[Parameters] = None
     function: Optional[constr(pattern=r'^[a-zA-Z0-9._-]+$')] = Field(
         'run', description='The function of the platform action.', examples=['run']
@@ -163,7 +168,11 @@ class PlatformAction(BaseModel):
     )
     environment: Optional[Environment] = Field(None, description='Environment variables for this platform action.')
     platform: Optional[Target] = Field(None, description='Ignored for this action.')
+    kind: Optional[str] = Field(None, description='The kind of the platform action.', examples=['junit'])
     docker: Optional[Docker] = Field(None, description='The docker configuration that is used to execute the action')
+    always: Optional[bool] = Field(
+        False, description='If this is set to true, the action is always executed, even if other actions fail.'
+    )
 
 
 class Author(RootModel):

--- a/cli/classes/generator.py
+++ b/cli/classes/generator.py
@@ -1,4 +1,3 @@
-import typing
 from typing import Optional
 
 from classes.generated.definitions import (
@@ -22,11 +21,7 @@ class Generator(PassSettings):
     publish: bool
 
     def __init__(
-        self,
-        input_settings: InputSettings,
-        output_settings: OutputSettings,
-        target: Target,
-        check_syntax: bool
+        self, input_settings: InputSettings, output_settings: OutputSettings, target: Target, check_syntax: bool
     ):
         validator: Validator = Validator(output_settings=output_settings, input_settings=input_settings)
         validated: Optional[WindFile] = validator.validate_wind_file()
@@ -54,6 +49,10 @@ class Generator(PassSettings):
         self.check_syntax = check_syntax
 
     def generate(self) -> None:
+        """
+        Generates the CI file from the given windfile.
+        :return:
+        """
         if not self.windfile:
             logger.error("❌ ", "Merging failed. Aborting.", self.output_settings.emoji)
             return None

--- a/cli/classes/generator.py
+++ b/cli/classes/generator.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Optional
 
 from classes.generated.definitions import (
@@ -18,13 +19,14 @@ from utils import logger
 class Generator(PassSettings):
     check_syntax: bool
     target: Target
+    publish: bool
 
     def __init__(
         self,
         input_settings: InputSettings,
         output_settings: OutputSettings,
         target: Target,
-        check_syntax: bool,
+        check_syntax: bool
     ):
         validator: Validator = Validator(output_settings=output_settings, input_settings=input_settings)
         validated: Optional[WindFile] = validator.validate_wind_file()
@@ -47,6 +49,7 @@ class Generator(PassSettings):
             windfile=windfile,
             metadata=merger.metadata,
         )
+
         self.target = target
         self.check_syntax = check_syntax
 
@@ -54,22 +57,7 @@ class Generator(PassSettings):
         if not self.windfile:
             logger.error("❌ ", "Merging failed. Aborting.", self.output_settings.emoji)
             return None
-        # current_action: FileAction | InternalAction | PlatformAction |
-        # ExternalAction = self.windfile.actions[
-        #     "hello-world_0"
-        # ].root
-        # if not isinstance(current_action, InternalAction):
-        #     logger.error(
-        #         "❌",
-        #         "Merging did not result in all internal actions",
-        #         self.output_settings.emoji,
-        #     )
-        #     return
-        # action: InternalAction = current_action
-        # code: str = action.script
-        # print(code)
-        # print("calling:")
-        # execute_arbitrary_code(code, "build", "hello-world_0")
+
         actual_generator: Optional[CliGenerator | JenkinsGenerator | BambooGenerator] = None
         if self.target == Target.cli.name:
             actual_generator = CliGenerator(

--- a/cli/classes/input_settings.py
+++ b/cli/classes/input_settings.py
@@ -1,4 +1,5 @@
 from io import TextIOWrapper
+from typing import Optional
 
 
 class InputSettings:
@@ -7,8 +8,8 @@ class InputSettings:
     """
 
     file_path: str
-    file: TextIOWrapper
+    file: Optional[TextIOWrapper]
 
-    def __init__(self, file_path: str, file: TextIOWrapper):
+    def __init__(self, file_path: str, file: Optional[TextIOWrapper] = None):
         self.file_path = file_path
         self.file = file

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -378,6 +378,7 @@ class Merger(PassSettings):
                             environment=internals.root.environment,
                             parameters=internals.root.parameters,
                             platform=internals.root.platform,
+                            docker=internals.root.docker
                         )
                     )
 
@@ -418,6 +419,7 @@ class Merger(PassSettings):
                         environment=internals.root.environment,
                         parameters=internals.root.parameters,
                         platform=internals.root.platform,
+                        docker=internals.root.docker
                     )
                 )
                 if internal:
@@ -456,6 +458,7 @@ class Merger(PassSettings):
                         environment=action.environment,
                         parameters=action.parameters,
                         platform=action.platform,
+                        docker=action.docker,
                     )
                 )
                 original_types.append("file")

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -122,7 +122,8 @@ class Merger(PassSettings):
         """
         logger.info("🏠 ", "Merging internal actions", self.output_settings.emoji)
         actions: List[tuple[str, Action]] = get_internal_actions_with_names(self.windfile)
-        print(actions)
+        for action in actions:
+            merge_docker(self.windfile.metadata.docker, self.windfile.actions[action[0]])
         self.set_original_types(names=[action_tuple[0] for action_tuple in actions], key="internal")
         self.set_original_names(names=[action_tuple[0] for action_tuple in actions])
         return True

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -269,7 +269,7 @@ class Merger(PassSettings):
                         typing.List[Action],
                     ]
                 ] = None
-                if isinstance(action, PlatformAction, FileAction):
+                if isinstance(action, (PlatformAction, FileAction)):
                     path = action.file
                     if isinstance(action, PlatformAction):
                         if path is None:

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -120,6 +120,8 @@ class Merger(PassSettings):
         Mainly sets metadata needed for the generation process.
         :return: True if the internal actions could be merged, False otherwise
         """
+        if self.windfile is None:
+            return False
         logger.info("🏠 ", "Merging internal actions", self.output_settings.emoji)
         actions: List[tuple[str, Action]] = get_internal_actions_with_names(self.windfile)
         for action in actions:

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -269,13 +269,11 @@ class Merger(PassSettings):
                         typing.List[Action],
                     ]
                 ] = None
-                if isinstance(action, PlatformAction):
-                    if action.file is not None:
-                        path = action.file
-                    else:
-                        converted = ([name], [Action(root=action)])
-                if isinstance(action, FileAction):
+                if isinstance(action, PlatformAction, FileAction):
                     path = action.file
+                    if isinstance(action, PlatformAction):
+                        if path is None:
+                            converted = ([name], [Action(root=action)])
                 elif isinstance(action, ExternalAction):
                     path = action.use
                 if path:

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -378,7 +378,7 @@ class Merger(PassSettings):
                             environment=internals.root.environment,
                             parameters=internals.root.parameters,
                             platform=internals.root.platform,
-                            docker=internals.root.docker
+                            docker=internals.root.docker,
                         )
                     )
 
@@ -419,7 +419,7 @@ class Merger(PassSettings):
                         environment=internals.root.environment,
                         parameters=internals.root.parameters,
                         platform=internals.root.platform,
-                        docker=internals.root.docker
+                        docker=internals.root.docker,
                     )
                 )
                 if internal:

--- a/cli/classes/merger.py
+++ b/cli/classes/merger.py
@@ -379,17 +379,19 @@ class Merger(PassSettings):
                             parameters=internals.root.parameters,
                             platform=internals.root.platform,
                             docker=internals.root.docker,
+                            always=internals.root.always,
                         )
                     )
 
                 elif isinstance(internals.root, PlatformAction):
                     original_types.append("platform")
-                    content = get_content_of(
-                        file=os.path.join(
-                            os.path.dirname(absolute_path),
-                            internals.root.file,
+                    if internals.root.file:
+                        content = get_content_of(
+                            file=os.path.join(
+                                os.path.dirname(absolute_path),
+                                internals.root.file,
+                            )
                         )
-                    )
                 elif isinstance(internals.root, FileAction):
                     original_types.append("file")
                     content = get_content_of(
@@ -420,6 +422,7 @@ class Merger(PassSettings):
                         parameters=internals.root.parameters,
                         platform=internals.root.platform,
                         docker=internals.root.docker,
+                        always=internals.root.always,
                     )
                 )
                 if internal:
@@ -459,6 +462,7 @@ class Merger(PassSettings):
                         parameters=action.parameters,
                         platform=action.platform,
                         docker=action.docker,
+                        always=action.always,
                     )
                 )
                 original_types.append("file")

--- a/cli/classes/output_settings.py
+++ b/cli/classes/output_settings.py
@@ -18,7 +18,7 @@ class OutputSettings:
         verbose: bool = False,
         debug: bool = False,
         emoji: bool = False,
-        ci_credentials: Optional[str] = None,
+        ci_credentials: Optional[CICredentials] = None,
     ):
         self.verbose = verbose
         self.debug = debug

--- a/cli/classes/output_settings.py
+++ b/cli/classes/output_settings.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+
 class OutputSettings:
     """
     Output settings for the CLI.
@@ -6,8 +9,19 @@ class OutputSettings:
     verbose: bool = False
     debug: bool = False
     emoji: bool = False
+    ci_url: Optional[str] = None
+    ci_token: Optional[str] = None
 
-    def __init__(self, verbose: bool = False, debug: bool = False, emoji: bool = False):
+    def __init__(
+        self,
+        verbose: bool = False,
+        debug: bool = False,
+        emoji: bool = False,
+        ci_url: Optional[str] = None,
+        ci_token: Optional[str] = None,
+    ):
         self.verbose = verbose
         self.debug = debug
         self.emoji = emoji
+        self.ci_url = ci_url
+        self.ci_token = ci_token

--- a/cli/classes/output_settings.py
+++ b/cli/classes/output_settings.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from classes.ci_credentials import CICredentials
+
 
 class OutputSettings:
     """
@@ -9,19 +11,16 @@ class OutputSettings:
     verbose: bool = False
     debug: bool = False
     emoji: bool = False
-    ci_url: Optional[str] = None
-    ci_token: Optional[str] = None
+    ci_credentials: Optional[CICredentials] = None
 
     def __init__(
         self,
         verbose: bool = False,
         debug: bool = False,
         emoji: bool = False,
-        ci_url: Optional[str] = None,
-        ci_token: Optional[str] = None,
+        ci_credentials: Optional[str] = None,
     ):
         self.verbose = verbose
         self.debug = debug
         self.emoji = emoji
-        self.ci_url = ci_url
-        self.ci_token = ci_token
+        self.ci_credentials = ci_credentials

--- a/cli/classes/translator.py
+++ b/cli/classes/translator.py
@@ -45,15 +45,10 @@ class BambooTranslator(PassSettings):
         input_settings: InputSettings,
         output_settings: OutputSettings,
         url: str,
-        token: str,
-        target: Target = Target.bamboo,
+        token: str
     ):
         super().__init__(input_settings=input_settings, output_settings=output_settings)
-        if target != Target.bamboo:
-            print("BambooTranslator only supports Bamboo as target")
-            sys.exit(1)
         self.client = BambooClient(url=url, token=token)
-        self.target = target
 
     def combine_docker_config(self, windfile: WindFile):
         docker_configs: dict[str, Optional[Docker]] = {}
@@ -86,7 +81,7 @@ class BambooTranslator(PassSettings):
         self, stages: dict[str, BambooStage], repositories: dict[str, BambooRepository]
     ) -> dict[str, Repository]:
         found: dict[str, Repository] = {}
-        for stage_name, stage in stages.items():
+        for _, stage in stages.items():
             for job_name in stage.jobs:
                 job: BambooJob = stage.jobs[job_name]
                 for task in job.tasks:

--- a/cli/classes/translator.py
+++ b/cli/classes/translator.py
@@ -11,6 +11,7 @@ from classes.bamboo_specs import (
     BambooCheckoutTask,
     BambooTask,
     BambooRepository,
+    BambooSpecialTask,
 )
 from classes.bamboo_client import BambooClient
 from classes.generated.definitions import (
@@ -28,12 +29,133 @@ from classes.generated.definitions import (
     PlatformAction,
     FileAction,
     ExternalAction,
+    Parameters,
 )
 from classes.generated.windfile import WindFile
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
 from classes.pass_settings import PassSettings
 from utils import logger
+
+
+def extract_action(job: BambooJob, task: BambooTask) -> Optional[Action]:
+    """
+    Converts the given task of the given Job into an Action.
+    Setting the conditions and environment variables fetched from Bamboo
+    :param job: Job containing the task we want to convert
+    :param task: Task to convert
+    :return: converted Action
+    """
+    exclude: list[Lifecycle] = []
+    if task.condition is not None:
+        for condition in task.condition.variables:
+            for match in condition.matches:
+                regex = re.compile(r"[^a-zA-Z |_]")
+                lifecycle = condition.matches[match]
+                for entry in regex.sub("", lifecycle).split("|"):
+                    exclude.append(Lifecycle[entry])
+    script_task: BambooTask = task
+    docker: Optional[Docker] = None
+    if job.docker is not None:
+        volume_list: list[str] = []
+        for volume in job.docker.volumes:
+            volume_list.append(f"{volume}:{job.docker.volumes[volume]}")
+        docker = Docker(
+            image=job.docker.image if ":" not in job.docker.image else job.docker.image.split(":")[0],
+            tag=job.docker.image.split(":")[1] if ":" in job.docker.image else "latest",
+            volumes=volume_list,
+            parameters=job.docker.docker_run_arguments,
+        )
+    environment: Environment = Environment(root=Dictionary(root=script_task.environment))
+    action: Optional[Action] = None
+    if isinstance(task, BambooSpecialTask):
+        if isinstance(task, BambooSpecialTask):
+            action = Action(
+                root=PlatformAction(
+                    parameters=Parameters(root=Dictionary(root=task.parameters)),
+                    kind=task.task_type,
+                    excludeDuring=exclude,
+                    file=None,
+                    function=None,
+                    docker=docker,
+                    environment=environment,
+                    platform=Target.bamboo,
+                    always=task.always_execute,
+                )
+            )
+    else:
+        action = Action(
+            root=InternalAction(
+                script="\n".join(script_task.scripts),
+                excludeDuring=exclude,
+                docker=docker,
+                environment=environment,
+                platform=None,
+                always=task.always_execute,
+            )
+        )
+    return action
+
+
+def extract_actions(stages: dict[str, BambooStage]) -> dict[Any, Action]:
+    """
+    Converts all jobs and tasks from the given stages (from the REST API)
+    into a dictionary of InternalActions.
+    :param stages: dict of stages from the REST API
+    :return: dict of InternalActions
+    """
+    actions: dict[Any, Action] = {}
+    for _, stage in stages.items():
+        for job_name in stage.jobs:
+            job: BambooJob = stage.jobs[job_name]
+            counter: int = 0
+            for task in job.tasks:
+                if isinstance(task, BambooTask):
+                    counter += 1
+                    action: Optional[Action] = extract_action(job=job, task=task)
+                    if action is not None:
+                        actions[job.key + str(counter)] = action
+    return actions
+
+
+def clean_up(windfile: WindFile) -> None:
+    """
+    Removes empty environment and parameters from the given windfile.
+    :param windfile:
+    """
+    for action in windfile.actions:
+        root_action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.actions[action].root
+        if root_action.environment is not None and len(root_action.environment.root.root) == 0:
+            root_action.environment = None
+        if root_action.parameters is not None and len(root_action.parameters.root.root) == 0:
+            root_action.parameters = None
+        if root_action.excludeDuring is not None and len(root_action.excludeDuring) == 0:
+            root_action.excludeDuring = None
+
+
+def extract_repositories(
+    stages: dict[str, BambooStage], repositories: dict[str, BambooRepository]
+) -> dict[str, Repository]:
+    """
+    Extracts the repositories from the given stages. So we can add them to the windfile.
+    :param stages: stages that possibly contain repositories in its tasks
+    :param repositories: repositories defined in the Build Plan
+    :return: dict of parsed repositories
+    """
+    found: dict[str, Repository] = {}
+    for _, stage in stages.items():
+        for job_name in stage.jobs:
+            job: BambooJob = stage.jobs[job_name]
+            for task in job.tasks:
+                if isinstance(task, BambooCheckoutTask):
+                    checkout: BambooCheckoutTask = task
+                    repository: Repository = Repository(
+                        url=repositories[checkout.repository].url,
+                        branch=repositories[checkout.repository].branch,
+                        path=checkout.path,
+                    )
+                    found[checkout.repository] = repository
+    return found
 
 
 class BambooTranslator(PassSettings):
@@ -45,6 +167,12 @@ class BambooTranslator(PassSettings):
         self.client = BambooClient(credentials=credentials)
 
     def combine_docker_config(self, windfile: WindFile) -> None:
+        """
+        Checks if all docker configurations are identical. If a bamboo plan is
+        configured to be run in docker, the docker configuration can be equal
+        in every action. So we can move the docker configuration to the metadata to make it easier to read.
+        :param windfile: Windfile to check
+        """
         docker_configs: dict[str, Optional[Docker]] = {}
         for action in windfile.actions:
             docker_configs[action] = windfile.actions[action].root.docker
@@ -61,79 +189,6 @@ class BambooTranslator(PassSettings):
             for action in windfile.actions:
                 windfile.actions[action].root.docker = None
 
-    def clean_up(self, windfile: WindFile) -> None:
-        for action in windfile.actions:
-            root_action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.actions[action].root
-            if root_action.environment is not None and len(root_action.environment.root.root) == 0:
-                root_action.environment = None
-            if root_action.parameters is not None and len(root_action.parameters.root.root) == 0:
-                root_action.parameters = None
-            if root_action.excludeDuring is not None and len(root_action.excludeDuring) == 0:
-                root_action.excludeDuring = None
-
-    def extract_respositories(
-        self, stages: dict[str, BambooStage], repositories: dict[str, BambooRepository]
-    ) -> dict[str, Repository]:
-        found: dict[str, Repository] = {}
-        for _, stage in stages.items():
-            for job_name in stage.jobs:
-                job: BambooJob = stage.jobs[job_name]
-                for task in job.tasks:
-                    if isinstance(task, BambooCheckoutTask):
-                        checkout: BambooCheckoutTask = task
-                        repository: Repository = Repository(
-                            url=repositories[checkout.repository].url,
-                            branch=repositories[checkout.repository].branch,
-                            path=checkout.path,
-                        )
-                        found[checkout.repository] = repository
-        return found
-
-    def extract_action(self, job: BambooJob, task: BambooTask) -> Action:
-        exclude: list[Lifecycle] = []
-        if task.condition is not None:
-            for condition in task.condition.variables:
-                for match in condition.matches:
-                    regex = re.compile(r"[^a-zA-Z |_]")
-                    lifecycle = condition.matches[match]
-                    for entry in regex.sub("", lifecycle).split("|"):
-                        exclude.append(Lifecycle[entry])
-        script_task: BambooTask = task
-        docker: Optional[Docker] = None
-        if job.docker is not None:
-            volume_list: list[str] = []
-            for volume in job.docker.volumes:
-                volume_list.append(f"{volume}:{job.docker.volumes[volume]}")
-            docker = Docker(
-                image=job.docker.image if ":" not in job.docker.image else job.docker.image.split(":")[0],
-                tag=job.docker.image.split(":")[1] if ":" in job.docker.image else "latest",
-                volumes=volume_list,
-                parameters=job.docker.docker_run_arguments,
-            )
-        environment: Environment = Environment(root=Dictionary(root=script_task.environment))
-        action: Action = Action(
-            root=InternalAction(
-                script="\n".join(script_task.scripts),
-                excludeDuring=exclude,
-                docker=docker,
-                environment=environment,
-                platform=None,
-            )
-        )
-        return action
-
-    def extract_actions(self, stages: dict[str, BambooStage]) -> dict[Any, Action]:
-        actions: dict[Any, Action] = {}
-        for _, stage in stages.items():
-            for job_name in stage.jobs:
-                job: BambooJob = stage.jobs[job_name]
-                counter: int = 0
-                for task in job.tasks:
-                    if isinstance(task, BambooTask):
-                        counter += 1
-                        actions[job.key + str(counter)] = self.extract_action(job=job, task=task)
-        return actions
-
     def translate(self, plan_key: str) -> Optional[WindFile]:
         """
         Translate the given build plan into a windfile.
@@ -145,10 +200,8 @@ class BambooTranslator(PassSettings):
         specs: BambooSpecs = optional[0]
         # raw: dict[str, str] = optional[1]
         plan: BambooPlan = specs.plan
-        actions: dict[Any, Action] = self.extract_actions(stages=specs.stages)
-        repositories: dict[str, Repository] = self.extract_respositories(
-            stages=specs.stages, repositories=specs.repositories
-        )
+        actions: dict[Any, Action] = extract_actions(stages=specs.stages)
+        repositories: dict[str, Repository] = extract_repositories(stages=specs.stages, repositories=specs.repositories)
         metadata: WindfileMetadata = WindfileMetadata(
             name=plan.name,
             description=plan.description,
@@ -161,7 +214,7 @@ class BambooTranslator(PassSettings):
             api=Api(root="v0.0.1"), metadata=metadata, actions=actions, repositories=repositories
         )
         self.combine_docker_config(windfile=windfile)
-        self.clean_up(windfile=windfile)
+        clean_up(windfile=windfile)
         # work-around as enums do not get cleanly printed with model_dump
         json: str = windfile.model_dump_json(exclude_none=True)
         logger.info("🪄", "Translated windfile", self.output_settings.emoji)

--- a/cli/classes/translator.py
+++ b/cli/classes/translator.py
@@ -2,7 +2,6 @@ from typing import Optional, Tuple, Any
 import re
 import yaml
 
-from classes.bamboo_credentials import BambooCredentials
 from classes.bamboo_specs import (
     BambooSpecs,
     BambooPlan,
@@ -206,6 +205,7 @@ class BambooTranslator(PassSettings):
             name=plan.name,
             description=plan.description,
             author=Author(root="bamboo"),
+            id=plan_key,
             docker=None,
             targets=None,
             gitCredentials=specs.repositories[list(specs.repositories.keys())[0]].shared_credentials,

--- a/cli/classes/translator.py
+++ b/cli/classes/translator.py
@@ -13,6 +13,7 @@ from classes.bamboo_specs import (
     BambooSpecialTask,
 )
 from classes.bamboo_client import BambooClient
+from classes.ci_credentials import CICredentials
 from classes.generated.definitions import (
     Target,
     WindfileMetadata,
@@ -161,7 +162,7 @@ class BambooTranslator(PassSettings):
     source: Target = Target.bamboo
     client: BambooClient
 
-    def __init__(self, input_settings: InputSettings, output_settings: OutputSettings, credentials: BambooCredentials):
+    def __init__(self, input_settings: InputSettings, output_settings: OutputSettings, credentials: CICredentials):
         super().__init__(input_settings=input_settings, output_settings=output_settings)
         self.client = BambooClient(credentials=credentials)
 

--- a/cli/classes/translator.py
+++ b/cli/classes/translator.py
@@ -1,0 +1,162 @@
+from typing import Optional, Tuple, Any
+import re
+import yaml
+
+from classes.bamboo_specs import BambooSpecs, BambooPlan, BambooJob, BambooStage, BambooCheckoutTask, BambooTask
+from classes.bamboo_client import BambooClient
+from classes.generated.definitions import (
+    Target,
+    WindfileMetadata,
+    InternalAction,
+    Repository,
+    Docker,
+    Api,
+    Author,
+    Environment,
+    Lifecycle,
+    Action,
+    Dictionary,
+    PlatformAction,
+    FileAction,
+    ExternalAction,
+)
+from classes.generated.windfile import WindFile
+from classes.input_settings import InputSettings
+from classes.output_settings import OutputSettings
+from classes.pass_settings import PassSettings
+from utils import logger
+
+
+class BambooTranslator(PassSettings):
+    source: Target = Target.bamboo
+    client: BambooClient
+
+    def __init__(
+        self,
+        input_settings: InputSettings,
+        output_settings: OutputSettings,
+        url: str,
+        token: str,
+        target: Target = Target.bamboo,
+    ):
+        super().__init__(input_settings=input_settings, output_settings=output_settings)
+        if target != Target.bamboo:
+            print("BambooTranslator only supports Bamboo as target")
+            exit(1)
+        self.client = BambooClient(url=url, token=token)
+        self.target = target
+
+    def combine_docker_config(self, windfile: WindFile):
+        docker_configs: dict[str, Optional[Docker]] = {}
+        for action in windfile.actions:
+            docker_configs[action] = windfile.actions[action].root.docker
+        first: Optional[Docker] = list(docker_configs.values())[0]
+        are_identical: bool = True
+        for docker_config in docker_configs:
+            if first != docker_configs[docker_config]:
+                logger.info("🚧", "Docker configurations are not identical", self.output_settings.emoji)
+                are_identical = False
+                break
+        if are_identical:
+            logger.info("🚀", "Docker configurations are identical", self.output_settings.emoji)
+            windfile.metadata.docker = first
+            for action in windfile.actions:
+                windfile.actions[action].root.docker = None
+
+    def clean_up(self, windfile: WindFile) -> None:
+        for action in windfile.actions:
+            root_action: FileAction | InternalAction | PlatformAction | ExternalAction = windfile.actions[action].root
+            if (
+                root_action.environment is not None
+                and len(root_action.environment.root.root) == 0
+            ):
+                root_action.environment = None
+            if (
+                root_action.parameters is not None
+                and len(root_action.parameters.root.root) == 0
+            ):
+                root_action.parameters = None
+            if (
+                root_action.excludeDuring is not None
+                and len(root_action.excludeDuring) == 0
+            ):
+                root_action.excludeDuring = None
+
+    def translate(self, plan_key: str) -> Optional[WindFile]:
+        """
+        Translate the given build plan into a windfile.
+        :return: Windfile
+        """
+        optional: Optional[Tuple[BambooSpecs, dict[str, Any]]] = self.client.get_plan_yaml(plan_key=plan_key)
+        if optional is None:
+            return None
+        specs: BambooSpecs = optional[0]
+        # raw: dict[str, str] = optional[1]
+        plan: BambooPlan = specs.plan
+        actions: dict[Any, Action] = {}
+        repositories: dict[str, Repository] = {}
+        for stage_name in specs.stages:
+            stage: BambooStage = specs.stages[stage_name]
+            for job_name in stage.jobs:
+                job: BambooJob = stage.jobs[job_name]
+                counter: int = 0
+                for task in job.tasks:
+                    if isinstance(task, BambooCheckoutTask):
+                        checkout: BambooCheckoutTask = task
+                        repository: Repository = Repository(
+                            url=specs.repositories[checkout.repository].url,
+                            branch=specs.repositories[checkout.repository].branch,
+                            path=checkout.path,
+                        )
+                        repositories[checkout.repository] = repository
+                    elif isinstance(task, BambooTask):
+                        exclude: list[Lifecycle] = []
+                        if task.condition is not None:
+                            for condition in task.condition.variables:
+                                for match in condition.matches:
+                                    regex = re.compile("[^a-zA-Z\ \|\_]")
+                                    lifecycle = condition.matches[match]
+                                    for entry in regex.sub("", lifecycle).split("|"):
+                                        exclude.append(Lifecycle[entry])
+                        scriptTask: BambooTask = task
+                        docker: Optional[Docker] = None
+                        if job.docker is not None:
+                            volume_list: list[str] = []
+                            for volume in job.docker.volumes:
+                                volume_list.append(f"{volume}:{job.docker.volumes[volume]}")
+                            docker = Docker(
+                                image=job.docker.image
+                                if ":" not in job.docker.image
+                                else job.docker.image.split(":")[0],
+                                tag=job.docker.image.split(":")[1] if ":" in job.docker.image else "latest",
+                                volumes=volume_list,
+                                parameters=job.docker.docker_run_arguments,
+                            )
+                        environment: Environment = Environment(root=Dictionary(root=scriptTask.environment))
+                        action: Action = Action(root=InternalAction(
+                            script="\n".join(scriptTask.scripts),
+                            excludeDuring=exclude,
+                            docker=docker,
+                            environment=environment,
+                            platform=None,
+                        ))
+                        counter += 1
+                        actions[job.key + str(counter)] = action
+        metadata: WindfileMetadata = WindfileMetadata(
+            name=plan.name,
+            description=plan.description,
+            author=Author(root="bamboo"),
+            docker=None,
+            targets=None,
+            gitCredentials=specs.repositories[list(specs.repositories.keys())[0]].shared_credentials,
+        )
+        windfile: WindFile = WindFile(
+            api=Api(root="v0.0.1"), metadata=metadata, actions=actions, repositories=repositories
+        )
+        self.combine_docker_config(windfile=windfile)
+        self.clean_up(windfile=windfile)
+        # work-around as enums do not get cleanly printed with model_dump
+        json: str = windfile.model_dump_json(exclude_none=True)
+        logger.info("🪄", "Translated windfile", self.output_settings.emoji)
+        print(yaml.dump(yaml.safe_load(json), sort_keys=False))
+        return None

--- a/cli/classes/validator.py
+++ b/cli/classes/validator.py
@@ -166,13 +166,15 @@ def read_file(
         return None
 
 
-def read_windfile(file: TextIOWrapper, output_settings: OutputSettings) -> Optional[WindFile]:
+def read_windfile(file: Optional[TextIOWrapper], output_settings: OutputSettings) -> Optional[WindFile]:
     """
     Validates the given file. If the file is valid, the windfile is returned.
     :param file: file to read
     :param output_settings: OutputSettings
     :return: Windfile or None
     """
+    if file is None:
+        return None
     # this shuts mypy up about the type
     windfile: type[WindFile] | None = read_file(filetype=WindFile, file=file, output_settings=output_settings)
     if isinstance(windfile, WindFile):
@@ -180,7 +182,7 @@ def read_windfile(file: TextIOWrapper, output_settings: OutputSettings) -> Optio
     return None
 
 
-def read_action_file(file: TextIOWrapper, output_settings: OutputSettings) -> Optional[ActionFile]:
+def read_action_file(file: Optional[TextIOWrapper], output_settings: OutputSettings) -> Optional[ActionFile]:
     """
     Validates the given file. If the file is valid,
     the ActionFile is returned.
@@ -189,6 +191,8 @@ def read_action_file(file: TextIOWrapper, output_settings: OutputSettings) -> Op
     :return: ActionFile or None
     """
     # this shuts mypy up about the type
+    if file is None:
+        return None
     action_file: type[ActionFile] | None = read_file(filetype=ActionFile, file=file, output_settings=output_settings)
     if isinstance(action_file, ActionFile):
         return action_file

--- a/cli/commands/generate.py
+++ b/cli/commands/generate.py
@@ -63,6 +63,24 @@ class Generate(Subcommand):
             action="store_true",
         )
 
+        parser.add_argument(
+            "--publish",
+            "-p",
+            help="Publish the generated file to the CI system",
+            action="store_true",
+        )
+
+        parser.add_argument(
+            "--url",
+            help="URL of the Bamboo Server",
+            type=str,
+        )
+        parser.add_argument(
+            "--token",
+            help="Auth token for the Bamboo Server",
+            type=str,
+        )
+
     def generate(self) -> None:
         """
         Generate the CI file.

--- a/cli/commands/translate.py
+++ b/cli/commands/translate.py
@@ -1,0 +1,69 @@
+import typing
+
+import argparse
+
+from classes.translator import BambooTranslator
+from classes.generated.definitions import Target
+from classes.generator import Generator
+from classes.input_settings import InputSettings
+from classes.output_settings import OutputSettings
+from commands.subcommand import Subcommand
+
+
+class Translate(Subcommand):
+    """
+    Translate subcommand. Retrieves the CI job
+    from the CI system and translates it into a
+    windfile.
+    """
+
+    translator: BambooTranslator
+
+    def __init__(
+        self,
+        input_settings: InputSettings,
+        output_settings: OutputSettings,
+        url: str,
+        token: str,
+        args: typing.Any,
+    ):
+        super().__init__(args)
+
+        self.translator = BambooTranslator(
+            input_settings=input_settings, output_settings=output_settings, target=Target.bamboo, url=url, token=token
+        )
+
+    @staticmethod
+    def add_arg_parser(parser: argparse.ArgumentParser) -> None:
+        """
+        Add arguments for this subcommand to the given parser.
+        :param parser:
+        """
+        parser.add_argument(
+            "--key",
+            "-k",
+            help="Build Plan Key",
+            default="AEOLUS-BASE1",
+            required=True,
+            type=str,
+        )
+
+        parser.add_argument(
+            "--url",
+            help="URL of the Bamboo Server",
+            required=True,
+            type=str,
+        )
+        parser.add_argument(
+            "--token",
+            "-t",
+            help="Auth token for the Bamboo Server",
+            required=True,
+            type=str,
+        )
+
+    def translate(self, plan_key: str) -> None:
+        """
+        Generate the CI file.
+        """
+        self.translator.translate(plan_key=plan_key)

--- a/cli/commands/translate.py
+++ b/cli/commands/translate.py
@@ -2,7 +2,6 @@ import typing
 
 import argparse
 
-from classes.bamboo_credentials import BambooCredentials
 from classes.translator import BambooTranslator
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings

--- a/cli/commands/translate.py
+++ b/cli/commands/translate.py
@@ -4,7 +4,6 @@ import argparse
 
 from classes.translator import BambooTranslator
 from classes.generated.definitions import Target
-from classes.generator import Generator
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
 from commands.subcommand import Subcommand

--- a/cli/commands/translate.py
+++ b/cli/commands/translate.py
@@ -2,6 +2,7 @@ import typing
 
 import argparse
 
+from classes.ci_credentials import CICredentials
 from classes.translator import BambooTranslator
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
@@ -21,7 +22,7 @@ class Translate(Subcommand):
         self,
         input_settings: InputSettings,
         output_settings: OutputSettings,
-        credentials: BambooCredentials,
+        credentials: CICredentials,
         args: typing.Any,
     ):
         super().__init__(args)

--- a/cli/commands/translate.py
+++ b/cli/commands/translate.py
@@ -29,7 +29,7 @@ class Translate(Subcommand):
         super().__init__(args)
 
         self.translator = BambooTranslator(
-            input_settings=input_settings, output_settings=output_settings, target=Target.bamboo, url=url, token=token
+            input_settings=input_settings, output_settings=output_settings, url=url, token=token
         )
 
     @staticmethod

--- a/cli/commands/translate.py
+++ b/cli/commands/translate.py
@@ -2,8 +2,8 @@ import typing
 
 import argparse
 
+from classes.bamboo_credentials import BambooCredentials
 from classes.translator import BambooTranslator
-from classes.generated.definitions import Target
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
 from commands.subcommand import Subcommand
@@ -22,14 +22,13 @@ class Translate(Subcommand):
         self,
         input_settings: InputSettings,
         output_settings: OutputSettings,
-        url: str,
-        token: str,
+        credentials: BambooCredentials,
         args: typing.Any,
     ):
         super().__init__(args)
 
         self.translator = BambooTranslator(
-            input_settings=input_settings, output_settings=output_settings, url=url, token=token
+            input_settings=input_settings, output_settings=output_settings, credentials=credentials
         )
 
     @staticmethod

--- a/cli/examples/bamboo/bamboospecs.yaml
+++ b/cli/examples/bamboo/bamboospecs.yaml
@@ -1,0 +1,118 @@
+---
+version: 2
+plan:
+  project-key: AEOLUS
+  key: BASE1
+  name: example windfile
+  description: Plan created from stdin
+stages:
+- Checkout:
+    manual: false
+    final: false
+    jobs:
+    - Checkout
+- internal-action:
+    manual: false
+    final: false
+    jobs:
+    - internal-action
+- external-action:
+    manual: false
+    final: false
+    jobs:
+    - external-action
+Checkout:
+  key: CHECKOUT1
+  tasks:
+  - checkout:
+      repository: aeolus
+      path: .
+      force-clean-build: false
+  artifact-subscriptions: []
+internal-action:
+  key: INTERNALACTION1
+  tasks:
+# Checkout Task for default repository will be added implicitly during Specs import
+  - script:
+      interpreter: SHELL
+      scripts:
+      - echo "⚙️ Executing internal-action"
+      description: dummy task to prevent wrong result of build plan run
+  - script:
+      interpreter: SHELL
+      scripts:
+      - |
+        echo "This is an internal action"
+      description: internal-action
+  artifact-subscriptions: []
+external-action:
+  key: EXTERNALACTION2
+  tasks:
+# Checkout Task for default repository will be added implicitly during Specs import
+  - script:
+      interpreter: SHELL
+      scripts:
+      - echo "⚙️ Executing external-action if stage is correct"
+      description: dummy task to prevent wrong result of build plan run
+  - script:
+      interpreter: SHELL
+      scripts:
+      - echo "Hello ${WHO_TO_GREET}"
+      environment: WHO_TO_GREET=world
+      conditions:
+      - variable:
+          matches:
+            lifecycle_stage: ^.*[^(preparation)].*
+      description: external-action
+  artifact-subscriptions: []
+variables:
+  lifecycle_stage: evaluation
+repositories:
+- aeolus:
+    type: git
+    url: https://github.com/ls1intum/Aeolus.git
+    branch: develop
+    shared-credentials: artemis_gitlab_admin_credentials
+    command-timeout-minutes: '180'
+    lfs: false
+    verbose-logs: false
+    use-shallow-clones: true
+    cache-on-agents: false
+    submodules: false
+    ssh-key-applies-to-submodules: false
+    fetch-all: false
+triggers: []
+branches:
+  create: manually
+  delete: never
+  link-to-jira: true
+notifications: []
+labels: []
+dependencies:
+  require-all-stages-passing: false
+  enabled-for-branches: true
+  block-strategy: none
+  plans: []
+other:
+  concurrent-build-plugin: system-default
+  force-stop-build: true
+---
+version: 2
+plan:
+  key: AEOLUS-BASE1
+plan-permissions:
+- roles:
+  - logged-in
+  - anonymous
+  permissions:
+  - view
+- users:
+  - artemis_admin
+  permissions:
+  - view
+  - edit
+  - build
+  - clone
+  - admin
+  - view-configuration
+...

--- a/cli/examples/windfiles/translated-from-bamboo.yaml
+++ b/cli/examples/windfiles/translated-from-bamboo.yaml
@@ -1,0 +1,44 @@
+api: v0.0.1
+metadata:
+  name: ARTEMISTESTUSER1
+  description: Build plan for exercise BAMBOOEX3
+  author: bamboo
+  gitCredentials: artemis_admin
+  docker:
+    image: ls1tum/artemis-maven-template
+    tag: java17-20
+    volumes:
+    - ${bamboo.working.directory}:${bamboo.working.directory}
+    - ${bamboo.tmp.directory}:${bamboo.tmp.directory}
+    parameters:
+    - --cpus
+    - '"2"'
+    - --memory
+    - '"2g"'
+    - --memory-swap
+    - '"2g"'
+    - --pids-limit
+    - '"1000"'
+repositories:
+  tests:
+    url: http://bitbucket:7990/scm/bambooex3/bambooex3-tests.git
+    branch: main
+    path: ''
+  assignment:
+    url: http://bitbucket:7990/scm/BAMBOOEX3/bambooex3-artemis_test_user_1.git
+    branch: main
+    path: assignment
+actions:
+  JOB11:
+    script: ./gradlew clean test
+    always: false
+  JOB12:
+    parameters:
+      ignore_time: 0.0
+      test_results: '**/test-results/test/*.xml'
+    platform: bamboo
+    kind: junit
+    always: true
+  JOB13:
+    script: chmod -R 777 ${bamboo.working.directory}
+    always: true

--- a/cli/examples/windfiles/translated-from-bamboo.yaml
+++ b/cli/examples/windfiles/translated-from-bamboo.yaml
@@ -3,7 +3,7 @@ metadata:
   name: ARTEMISTESTUSER1
   description: Build plan for exercise BAMBOOEX3
   author: bamboo
-  gitCredentials: artemis_admin
+  gitCredentials: artemis_gitlab_admin_credentials
   docker:
     image: ls1tum/artemis-maven-template
     tag: java17-20
@@ -34,7 +34,7 @@ actions:
     always: false
   JOB12:
     parameters:
-      ignore_time: 0.0
+      ignore_time: false
       test_results: '**/test-results/test/*.xml'
     platform: bamboo
     kind: junit

--- a/cli/examples/windfiles/windfile-with-failing-action.yml
+++ b/cli/examples/windfiles/windfile-with-failing-action.yml
@@ -1,0 +1,19 @@
+api: v0.0.1
+metadata:
+  name: windfile-with-internal-action
+  description: This is a windfile with an internal action
+  author: Andreas Resch
+actions:
+  internal-action:
+    script: |
+      echo "Hello from an internal action"
+    parameters:
+      WHO: "me"
+  failing:
+    script: |
+      echo "This action will fail"
+      exit 1
+  debug:
+    script: |
+      echo "This action will still run"
+    always: true

--- a/cli/generators/bamboo.py
+++ b/cli/generators/bamboo.py
@@ -60,6 +60,8 @@ class BambooGenerator(BaseGenerator):
         :param base64_str: windfile definition as base64 encoded string
         """
         command: List[str] = ["java", "-jar", "bamboo-generator.jar", "--base64", base64_str]
+        if self.output_settings.ci_url and self.output_settings.ci_token:
+            command += ["--server", self.output_settings.ci_url, "--token", self.output_settings.ci_token]
         process: subprocess.CompletedProcess = subprocess.run(command, text=True, capture_output=True, check=True)
         error_logs: str = process.stderr.split("\n")
         for error_log in error_logs:
@@ -80,9 +82,12 @@ class BambooGenerator(BaseGenerator):
         """
         client: DockerClient = DockerClient.from_env()
         container_name: str = "bambeolus"
+        command: str = f"--base64 {base64_str}"
+        if self.output_settings.ci_url and self.output_settings.ci_token:
+            command += f" --publish --server {self.output_settings.ci_url} --token {self.output_settings.ci_token}"
         client.containers.run(
-            image="ghcr.io/ls1intum/aeolus/bamboo-generator:nightly",
-            command=f"--base64 {base64_str}",
+            image="bambeolus",
+            command=f"{command}",
             auto_remove=False,
             name=container_name,
             detach=True,

--- a/cli/generators/bamboo.py
+++ b/cli/generators/bamboo.py
@@ -60,8 +60,13 @@ class BambooGenerator(BaseGenerator):
         :param base64_str: windfile definition as base64 encoded string
         """
         command: List[str] = ["java", "-jar", "bamboo-generator.jar", "--base64", base64_str]
-        if self.output_settings.ci_url and self.output_settings.ci_token:
-            command += ["--server", self.output_settings.ci_url, "--token", self.output_settings.ci_token]
+        if self.output_settings.ci_credentials is not None:
+            command += [
+                "--server",
+                self.output_settings.ci_credentials.url,
+                "--token",
+                self.output_settings.ci_credentials.token,
+            ]
         process: subprocess.CompletedProcess = subprocess.run(command, text=True, capture_output=True, check=True)
         error_logs: str = process.stderr.split("\n")
         for error_log in error_logs:
@@ -83,8 +88,9 @@ class BambooGenerator(BaseGenerator):
         client: DockerClient = DockerClient.from_env()
         container_name: str = "bambeolus"
         command: str = f"--base64 {base64_str}"
-        if self.output_settings.ci_url and self.output_settings.ci_token:
-            command += f" --publish --server {self.output_settings.ci_url} --token {self.output_settings.ci_token}"
+        if self.output_settings.ci_credentials is not None:
+            command += f" --publish --server {self.output_settings.ci_credentials.url}"
+            command += f"--token {self.output_settings.ci_credentials.token}"
         client.containers.run(
             image="bambeolus",
             command=f"{command}",

--- a/cli/generators/base.py
+++ b/cli/generators/base.py
@@ -37,7 +37,7 @@ class BaseGenerator:
         Check if there are always actions in the windfile.
         """
         for _, action in self.windfile.actions.items():
-            if "always" in action.root.__dict__ and action.root.always:
+            if action.root.always:
                 return True
         return False
 

--- a/cli/generators/base.py
+++ b/cli/generators/base.py
@@ -32,11 +32,21 @@ class BaseGenerator:
         self.metadata = metadata
         self.result = []
 
-    def handle_step(self, name: str, step: InternalAction) -> None:
+    def has_always_actions(self) -> bool:
+        """
+        Check if there are always actions in the windfile.
+        """
+        for name, action in self.windfile.actions.items():
+            if action.root.always:
+                return True
+        return False
+
+    def handle_step(self, name: str, step: InternalAction, call: bool) -> None:
         """
         Translate a step into a CI action.
         :param name: name of the step to handle
         :param step: step to translate
+        :param call: whether to call the step or not
         :return: CI action
         """
         raise NotImplementedError("handle_step() not implemented")

--- a/cli/generators/base.py
+++ b/cli/generators/base.py
@@ -36,8 +36,8 @@ class BaseGenerator:
         """
         Check if there are always actions in the windfile.
         """
-        for name, action in self.windfile.actions.items():
-            if action.root.always:
+        for _, action in self.windfile.actions.items():
+            if "always" in action.root.__dict__ and action.root.always:
                 return True
         return False
 

--- a/cli/generators/cli.py
+++ b/cli/generators/cli.py
@@ -3,7 +3,7 @@ import subprocess
 import tempfile
 from typing import List, Optional
 
-from classes.generated.definitions import InternalAction, Action, Repository
+from classes.generated.definitions import InternalAction, Repository
 from generators.base import BaseGenerator
 from utils import logger
 
@@ -51,12 +51,11 @@ class CliGenerator(BaseGenerator):
         :return: CI action
         """
         self.result.append("\n# always steps")
-        self.result.append(f"final_aeolus_post_action () " + "{")
+        self.result.append("final_aeolus_post_action () " + "{")
         self.result.append("  echo '⚙️ executing final_aeolus_post_action'")
         for step in steps:
             self.result.append(f"  {step} $_current_lifecycle")
         self.result.append("}")
-        return None
 
     def handle_step(self, name: str, step: InternalAction, call: bool) -> None:
         """

--- a/cli/generators/jenkins.py
+++ b/cli/generators/jenkins.py
@@ -177,7 +177,7 @@ class JenkinsGenerator(BaseGenerator):
         for name in self.windfile.actions:
             step: Action = self.windfile.actions[name]
             if isinstance(step.root, InternalAction) and not step.root.always:
-                self.handle_step(name=name, step=step.root)
+                self.handle_step(name=name, step=step.root, call=True)
         self.result.append("  }")
         if self.has_always_actions():
             self.result.append("  post {")

--- a/cli/generators/jenkins.py
+++ b/cli/generators/jenkins.py
@@ -67,13 +67,13 @@ class JenkinsGenerator(BaseGenerator):
             self.result.append("        '''")
         self.result.append("      }")
         self.result.append("    }")
-        return None
 
-    def handle_step(self, name: str, step: InternalAction) -> None:
+    def handle_step(self, name: str, step: InternalAction, call: bool) -> None:
         """
         Translate a step into a CI action.
         :param name: Name of the step to handle
         :param step: to translate
+        :param call: whether to call the step or not
         :return: CI action
         """
         original_name: Optional[str] = self.metadata.get_original_name_of(name)

--- a/cli/generators/jenkins.py
+++ b/cli/generators/jenkins.py
@@ -182,9 +182,9 @@ class JenkinsGenerator(BaseGenerator):
         if self.has_always_actions():
             self.result.append("  post {")
             for name in self.windfile.actions:
-                step: Action = self.windfile.actions[name]
-                if isinstance(step.root, InternalAction) and step.root.always:
-                    self.handle_always_step(name=name, step=step.root)
+                post_step: Action = self.windfile.actions[name]
+                if isinstance(post_step.root, InternalAction) and post_step.root.always:
+                    self.handle_always_step(name=name, step=post_step.root)
         self.add_postfix()
         return super().generate()
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,6 +13,7 @@ from commands.generate import Generate
 from commands.merge import Merge
 from commands.translate import Translate
 from commands.validate import Validate
+from utils import utils
 
 
 def add_argparse() -> argparse.ArgumentParser:
@@ -103,7 +104,7 @@ if __name__ == "__main__":
     if args.command == "generate":
         if args.publish:
             if not args.url or not args.token:
-                logger.error(
+                utils.logger.error(
                     "❌ ",
                     "Publishing requires a CI URL and a token",
                     output_settings.emoji,

--- a/cli/main.py
+++ b/cli/main.py
@@ -6,7 +6,6 @@ from io import TextIOWrapper
 import argparse
 import sys
 
-from classes.bamboo_credentials import BambooCredentials
 from classes.ci_credentials import CICredentials
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings

--- a/cli/main.py
+++ b/cli/main.py
@@ -58,8 +58,8 @@ def add_argparse() -> argparse.ArgumentParser:
     generator_parser = subparsers.add_parser(name="generate")
     Generate.add_arg_parser(parser=generator_parser)
 
-    bambootranslator_parser = subparsers.add_parser(name="translate")
-    Translate.add_arg_parser(parser=bambootranslator_parser)
+    bamboo_translator_parser = subparsers.add_parser(name="translate")
+    Translate.add_arg_parser(parser=bamboo_translator_parser)
     return arg_parser
 
 
@@ -79,7 +79,9 @@ if __name__ == "__main__":
     if args.command is None:
         parser.print_help()
         sys.exit(0)
-    output_settings: OutputSettings = OutputSettings(verbose=args.verbose, debug=args.debug, emoji=args.emoji)
+    output_settings: OutputSettings = OutputSettings(
+        verbose=args.verbose, debug=args.debug, emoji=args.emoji, ci_url=None, ci_token=None
+    )
     file_path: str = args.key if "translate" == args.command else args.input.name
     file: typing.Optional[TextIOWrapper] = None if "translate" == args.command else args.input
     input_settings: InputSettings = InputSettings(file_path=file_path, file=file)
@@ -99,6 +101,17 @@ if __name__ == "__main__":
         )
         merger.merge()
     if args.command == "generate":
+        if args.publish:
+            if not args.url or not args.token:
+                logger.error(
+                    "❌ ",
+                    "Publishing requires a CI URL and a token",
+                    output_settings.emoji,
+                )
+                raise ValueError("Publishing requires a Bamboo URL and a token")
+            output_settings.ci_url = args.url
+            output_settings.ci_token = args.token
+
         generator: Generate = Generate(
             input_settings=input_settings,
             output_settings=output_settings,

--- a/cli/main.py
+++ b/cli/main.py
@@ -7,6 +7,7 @@ import argparse
 import sys
 
 from classes.bamboo_credentials import BambooCredentials
+from classes.ci_credentials import CICredentials
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
 from commands.generate import Generate
@@ -80,7 +81,7 @@ if __name__ == "__main__":
         parser.print_help()
         sys.exit(0)
     output_settings: OutputSettings = OutputSettings(
-        verbose=args.verbose, debug=args.debug, emoji=args.emoji, ci_url=None, ci_token=None
+        verbose=args.verbose, debug=args.debug, emoji=args.emoji, ci_credentials=None
     )
     file_path: str = args.key if "translate" == args.command else args.input.name
     file: typing.Optional[TextIOWrapper] = None if "translate" == args.command else args.input
@@ -109,8 +110,7 @@ if __name__ == "__main__":
                     output_settings.emoji,
                 )
                 raise ValueError("Publishing requires a Bamboo URL and a token")
-            output_settings.ci_url = args.url
-            output_settings.ci_token = args.token
+            output_settings.ci_credentials = CICredentials(url=args.url, token=args.token)
 
         generator: Generate = Generate(
             input_settings=input_settings,

--- a/cli/main.py
+++ b/cli/main.py
@@ -6,7 +6,6 @@ from io import TextIOWrapper
 import argparse
 import sys
 
-from classes.translator import BambooTranslator
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
 from commands.generate import Generate
@@ -78,7 +77,7 @@ if __name__ == "__main__":
         logging.basicConfig(encoding="utf-8", level=logging.INFO, format="%(message)s")
     if args.command is None:
         parser.print_help()
-        exit(0)
+        sys.exit(0)
     output_settings: OutputSettings = OutputSettings(verbose=args.verbose, debug=args.debug, emoji=args.emoji)
     file_path: str = args.key if "translate" == args.command else args.input.name
     file: typing.Optional[TextIOWrapper] = None if "translate" == args.command else args.input

--- a/cli/main.py
+++ b/cli/main.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
         )
         generator.generate()
     if args.command == "translate":
-        credentials: BambooCredentials = BambooCredentials(url=args.url, token=args.token)
+        credentials: CICredentials = CICredentials(url=args.url, token=args.token)
         translator: Translate = Translate(
             input_settings=input_settings, output_settings=output_settings, credentials=credentials, args=args
         )

--- a/cli/main.py
+++ b/cli/main.py
@@ -6,6 +6,7 @@ from io import TextIOWrapper
 import argparse
 import sys
 
+from classes.bamboo_credentials import BambooCredentials
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
 from commands.generate import Generate
@@ -105,7 +106,8 @@ if __name__ == "__main__":
         )
         generator.generate()
     if args.command == "translate":
+        credentials: BambooCredentials = BambooCredentials(url=args.url, token=args.token)
         translator: Translate = Translate(
-            input_settings=input_settings, output_settings=output_settings, url=args.url, token=args.token, args=args
+            input_settings=input_settings, output_settings=output_settings, credentials=credentials, args=args
         )
         translator.translate(plan_key=args.key)

--- a/cli/requirements.in
+++ b/cli/requirements.in
@@ -11,3 +11,4 @@ pytest
 pydantic
 coverage
 gitpython
+types-requests

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -138,6 +138,8 @@ toml==0.10.2
     # via datamodel-code-generator
 types-pyyaml==6.0.12.11
     # via -r requirements.in
+types-requests==2.31.0.7
+    # via -r requirements.in
 typing-extensions==4.7.1
     # via
     #   mypy
@@ -147,6 +149,7 @@ urllib3==2.0.4
     # via
     #   docker
     #   requests
+    #   types-requests
 websocket-client==1.6.2
     # via docker
 wheel==0.41.1

--- a/schemas/v0.0.1/schemas/definitions.json
+++ b/schemas/v0.0.1/schemas/definitions.json
@@ -374,6 +374,7 @@
         "type": [
           "string",
           "number",
+          "boolean",
           "null"
         ]
       }

--- a/schemas/v0.0.1/schemas/definitions.json
+++ b/schemas/v0.0.1/schemas/definitions.json
@@ -166,10 +166,6 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "for": {
-        "description": "The platform that this action is defined for.",
-        "$ref": "#/target"
-      },
       "file": {
         "description": "The file of the platform action. Written in Python",
         "type": "string"
@@ -202,14 +198,30 @@
         "description": "Ignored for this action.",
         "$ref": "#/target"
       },
+      "kind": {
+        "description": "The kind of the platform action.",
+        "type": "string",
+        "examples": [
+          "junit"
+        ]
+      },
       "docker": {
         "description": "The docker configuration that is used to execute the action",
         "$ref": "#/docker"
+      },
+      "always": {
+        "description": "If this is set to true, the action is always executed, even if other actions fail.",
+        "type": "boolean",
+        "default": false
       }
     },
-    "required": [
-      "for",
-      "file"
+    "oneOff": [
+      {
+        "required": [
+          "for",
+          "file"
+        ]
+      }
     ]
   },
   "file-action": {
@@ -244,6 +256,11 @@
       "docker": {
         "description": "The docker configuration that is used to execute the action",
         "$ref": "#/docker"
+      },
+      "always": {
+        "description": "If this is set to true, the action is always executed, even if other actions fail.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": [
@@ -282,6 +299,11 @@
       "docker": {
         "description": "The docker configuration that is used to execute the action",
         "$ref": "#/docker"
+      },
+      "always": {
+        "description": "If this is set to true, the action is always executed, even if other actions fail.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": [

--- a/schemas/v0.0.1/schemas/definitions.json
+++ b/schemas/v0.0.1/schemas/definitions.json
@@ -343,6 +343,11 @@
       "docker": {
         "description": "The docker configuration that is used to execute the action",
         "$ref": "#/docker"
+      },
+      "always": {
+        "description": "If this is set to true, the action is always executed, even if other actions fail.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": [

--- a/schemas/v0.0.1/schemas/definitions.json
+++ b/schemas/v0.0.1/schemas/definitions.json
@@ -20,6 +20,15 @@
           "rust-exercise-jobs"
         ]
       },
+      "id": {
+        "description": "The id of the resulting job in the CI system.",
+        "type": "string",
+        "examples": [
+          "rust-exercise-jobs",
+          "AEOLUS-BASE",
+          "jenkins/job/path"
+        ]
+      },
       "description": {
         "description": "Description of what this list of actions is supposed to achieve",
         "type": "string",

--- a/schemas/v0.0.1/schemas/definitions.json
+++ b/schemas/v0.0.1/schemas/definitions.json
@@ -51,6 +51,10 @@
             "$ref": "#/git-credentials"
           }
         ]
+      },
+      "docker": {
+        "description": "The docker configuration that is used to execute the actions",
+        "$ref": "#/docker"
       }
     },
     "required": [
@@ -197,6 +201,10 @@
       "platform": {
         "description": "Ignored for this action.",
         "$ref": "#/target"
+      },
+      "docker": {
+        "description": "The docker configuration that is used to execute the action",
+        "$ref": "#/docker"
       }
     },
     "required": [
@@ -232,6 +240,10 @@
       "platform": {
         "description": "The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
         "$ref": "#/target"
+      },
+      "docker": {
+        "description": "The docker configuration that is used to execute the action",
+        "$ref": "#/docker"
       }
     },
     "required": [
@@ -266,6 +278,10 @@
       "platform": {
         "description": "The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
         "$ref": "#/target"
+      },
+      "docker": {
+        "description": "The docker configuration that is used to execute the action",
+        "$ref": "#/docker"
       }
     },
     "required": [
@@ -301,6 +317,10 @@
       "platform": {
         "description": "The platform that this action is defined for. If it's not set, the action is defined for all platforms.",
         "$ref": "#/target"
+      },
+      "docker": {
+        "description": "The docker configuration that is used to execute the action",
+        "$ref": "#/docker"
       }
     },
     "required": [
@@ -433,6 +453,52 @@
       "url",
       "branch",
       "path"
+    ]
+  },
+  "docker": {
+    "title": "Docker",
+    "description": "Docker configuration that is used to execute the actions",
+    "type": "object",
+    "allowAdditionalProperties": false,
+    "properties": {
+      "image": {
+        "description": "The docker image that is used to execute the action",
+        "type": "string",
+        "examples": [
+          "rust:latest"
+        ]
+      },
+      "tag": {
+        "description": "The tag of the docker image that is used to execute the action",
+        "type": "string",
+        "examples": [
+          "latest"
+        ],
+        "default": "latest"
+      },
+      "volumes": {
+        "description": "The volumes that are mounted into the docker container",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "examples": [
+            "/var/run/docker.sock:/var/run/docker.sock"
+          ]
+        }
+      },
+      "parameters": {
+        "description": "The parameters that are passed to the docker daemon, e.g. --cpus=2",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "examples": [
+            "--cpus=2"
+          ]
+        }
+      }
+    },
+    "required": [
+      "image"
     ]
   }
 }


### PR DESCRIPTION
This PR adds the possibility to translate build plans from bamboo directly into aeolus.
This has some advantages:
- makes editing basically possible, write build plan in bamboo, translate it to aeolus using the tool -> change windfile and regenerate the build plan in bamboo.

Furthermore, we add docker image support, so that we can define in the metadata of a windfile which docker images is used during the execution.