### PR TITLE
add runner for cli and jenkins, improve bamboo generation

### DIFF
--- a/bamboo-generator/src/main/java/de/tum/cit/ase/Main.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/Main.java
@@ -147,7 +147,7 @@ public class Main {
 
         BuildPlanService buildPlanService = new BuildPlanService();
         Project project = getEmptyProject(windFile.getMetadata());
-        Plan plan = new Plan(project, windFile.getMetadata().getName(), windFile.getMetadata().getPlanName()).description("Plan created from " + windFile.getFilePath()).variables(new Variable("lifecycle_stage", "evaluation"));
+        Plan plan = new Plan(project, windFile.getMetadata().getName(), windFile.getMetadata().getPlanName()).description("Plan created from " + windFile.getFilePath()).variables(new Variable("lifecycle_stage", "working_time"));
         boolean oneGlobalDockerConfig = windFile.getMetadata().getDocker() != null;
 
         Stage defaultStage = new Stage("Default Stage");

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
@@ -4,30 +4,44 @@ import com.atlassian.bamboo.specs.api.builders.AtlassianModule;
 import com.atlassian.bamboo.specs.api.builders.condition.AnyTaskCondition;
 import com.atlassian.bamboo.specs.api.builders.credentials.SharedCredentialsIdentifier;
 import com.atlassian.bamboo.specs.api.builders.credentials.SharedCredentialsScope;
+import com.atlassian.bamboo.specs.api.builders.docker.DockerConfiguration;
 import com.atlassian.bamboo.specs.api.builders.repository.VcsChangeDetection;
 import com.atlassian.bamboo.specs.api.builders.task.Task;
 import com.atlassian.bamboo.specs.builders.repository.git.GitRepository;
 import com.atlassian.bamboo.specs.builders.task.ScriptTask;
 import com.atlassian.bamboo.specs.builders.task.TestParserTask;
-import com.atlassian.bamboo.specs.model.task.TestParserTaskProperties;
+import de.tum.cit.ase.classes.DockerConfig;
 import de.tum.cit.ase.classes.InternalAction;
 import de.tum.cit.ase.classes.PlatformAction;
 import de.tum.cit.ase.classes.Repository;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class BuildPlanService {
 
+    public static DockerConfiguration convertDockerConfig(DockerConfig docker) {
+        if (docker == null) {
+            return null;
+        }
+        DockerConfiguration configuration = new DockerConfiguration()
+                .image(docker.getImage() + ":" + docker.getTag())
+                .dockerRunArguments(docker.getParameters().toArray(new String[0]));
+        for (Map.Entry<String, String> entry : docker.getVolumes().entrySet()) {
+            configuration.volume(entry.getKey(), entry.getValue());
+        }
+        return configuration;
+    }
+
     public GitRepository addRepository(Repository repository, String credentialsName) {
+        GitRepository repo = new GitRepository();
+        if (credentialsName != null) {
+            repo.authentication(new SharedCredentialsIdentifier(credentialsName)
+                    .scope(SharedCredentialsScope.GLOBAL));
+        }
         return new GitRepository()
                 .name(repository.getName())
                 .branch(repository.getBranch())
-                .authentication(new SharedCredentialsIdentifier(credentialsName)
-                        .scope(SharedCredentialsScope.GLOBAL))
                 .url(repository.getUrl())
                 .shallowClonesEnabled(true)
                 .remoteAgentCacheEnabled(false)

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/bamboo/BuildPlanService.java
@@ -77,12 +77,12 @@ public class BuildPlanService {
         ScriptTask task = new ScriptTask()
                 .description(action.getName())
                 .inlineBody(action.getScript());
-        String postfix = action.getExcludeDuring().isEmpty() ? "" : " if stage is correct";
-        String dummyTask = "echo \"⚙️ Executing " + action.getName() + postfix + "\"";
-        tasks.add(new ScriptTask().description("dummy task to prevent wrong result of build plan run")
-                .inlineBody(dummyTask));
 
         if (!action.getExcludeDuring().isEmpty()) {
+            String postfix = action.getExcludeDuring().isEmpty() ? "" : " if stage is correct";
+            String dummyTask = "echo \"⚙️ Executing " + action.getName() + postfix + "\"";
+            tasks.add(new ScriptTask().description("dummy task to prevent wrong result of build plan run")
+                    .inlineBody(dummyTask));
             var condMap = new HashMap<String, String>();
             condMap.put("operation", "matches");
             condMap.put("variable", "lifecycle_stage");

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/Action.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/Action.java
@@ -71,17 +71,4 @@ public abstract class Action {
     protected void setDocker(DockerConfig docker) {
         this.docker = docker;
     }
-
-    public DockerConfiguration convertDockerConfig() {
-        if (docker == null) {
-            return null;
-        }
-        DockerConfiguration configuration = new DockerConfiguration()
-                .image(docker.getImage() + ":" + docker.getTag())
-                .dockerRunArguments(docker.getParameters().toArray(new String[0]));
-        for (Map.Entry<String, String> entry : docker.getVolumes().entrySet()) {
-            configuration.volume(entry.getKey(), entry.getValue());
-        }
-        return configuration;
-    }
 }

--- a/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFileMetadata.java
+++ b/bamboo-generator/src/main/java/de/tum/cit/ase/classes/WindFileMetadata.java
@@ -19,7 +19,7 @@ public class WindFileMetadata {
         metadata.setDescription((String) map.get("description"));
         Object author = map.get("author");
         metadata.setAuthor(Author.fromObject(author));
-        metadata.setGitCredentials(Optional.ofNullable((String) map.get("gitCredentials")));
+        metadata.setGitCredentials(Optional.ofNullable((String) map.getOrDefault("gitCredentials", null)));
         metadata.setId((String) map.get("id"));
         metadata.setDocker(DockerConfig.fromMap((Map<String, Object>) map.getOrDefault("docker", null)));
         return metadata;

--- a/cli/classes/generator.py
+++ b/cli/classes/generator.py
@@ -100,4 +100,7 @@ class Generator(PassSettings):
                         "Syntax check failed",
                         self.output_settings.emoji,
                     )
+            if self.output_settings.run_settings is not None:
+                logger.info("🐳", "Running pipeline...", self.output_settings.emoji)
+                actual_generator.run()
         return None

--- a/cli/classes/generator.py
+++ b/cli/classes/generator.py
@@ -100,7 +100,19 @@ class Generator(PassSettings):
                         "Syntax check failed",
                         self.output_settings.emoji,
                     )
-            if self.output_settings.run_settings is not None:
-                logger.info("🐳", "Running pipeline...", self.output_settings.emoji)
-                actual_generator.run()
+            if (
+                self.output_settings.run_settings is not None
+                and self.windfile is not None
+                and self.windfile.metadata is not None
+                and self.windfile.metadata.id is not None
+            ):
+                actual_generator.run(job_id=self.windfile.metadata.id)
         return None
+
+    def run(self, job_id: str) -> None:
+        """
+        Run the generated CI file.
+        :param job_id: ID of the job to run
+        :return: None
+        """
+        raise NotImplementedError("run() not implemented")

--- a/cli/classes/output_settings.py
+++ b/cli/classes/output_settings.py
@@ -1,6 +1,8 @@
+# pylint: disable=too-many-arguments
 from typing import Optional
 
 from classes.ci_credentials import CICredentials
+from classes.run_settings import RunSettings
 
 
 class OutputSettings:
@@ -12,6 +14,7 @@ class OutputSettings:
     debug: bool = False
     emoji: bool = False
     ci_credentials: Optional[CICredentials] = None
+    run_settings: Optional[RunSettings] = None
 
     def __init__(
         self,
@@ -19,8 +22,10 @@ class OutputSettings:
         debug: bool = False,
         emoji: bool = False,
         ci_credentials: Optional[CICredentials] = None,
+        run_settings: Optional[RunSettings] = None,
     ):
         self.verbose = verbose
         self.debug = debug
         self.emoji = emoji
         self.ci_credentials = ci_credentials
+        self.run_settings = run_settings

--- a/cli/classes/run_settings.py
+++ b/cli/classes/run_settings.py
@@ -1,0 +1,12 @@
+from classes.generated.definitions import Lifecycle
+
+
+class RunSettings:
+    """
+    Run settings for the CI job.
+    """
+
+    def __init__(self, stage: Lifecycle = Lifecycle.preparation):
+        self.stage = stage
+
+    stage: Lifecycle

--- a/cli/commands/generate.py
+++ b/cli/commands/generate.py
@@ -2,6 +2,7 @@ import typing
 
 import argparse
 
+from classes.generated.definitions import Lifecycle
 from classes.generator import Generator
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
@@ -86,6 +87,10 @@ class Generate(Subcommand):
             "--token",
             help="Auth token for the CI Server",
             type=str,
+        )
+
+        parser.add_argument(
+            "--run", "-r", help="Run the generated file on the CI system", choices=Lifecycle.__members__.keys()
         )
 
     def generate(self) -> None:

--- a/cli/commands/generate.py
+++ b/cli/commands/generate.py
@@ -98,3 +98,10 @@ class Generate(Subcommand):
         Generate the CI file.
         """
         self.generator.generate()
+
+    def run(self, job_id: str) -> None:
+        """
+        Run the generated CI file on the CI system.
+        :param job_id: ID of the job to run
+        """
+        self.generator.run(job_id=job_id)

--- a/cli/generators/bamboo.py
+++ b/cli/generators/bamboo.py
@@ -5,6 +5,7 @@ import subprocess
 from typing import List
 from utils import logger
 
+import requests
 from generators.base import BaseGenerator
 from docker.models.containers import Container  # type: ignore
 from docker.client import DockerClient  # type: ignore
@@ -93,7 +94,7 @@ class BambooGenerator(BaseGenerator):
             command += f" --publish --server {self.output_settings.ci_credentials.url} "
             command += f"--token {self.output_settings.ci_credentials.token}"
         client.containers.run(
-            image=os.getenv("BAMBOO_GENERATOR_IMAGE", "ghcr.io/ls1intum/bamboo-generator:nightly"),
+            image=os.getenv("BAMBOO_GENERATOR_IMAGE", "ghcr.io/ls1intum/aeolus/bamboo-generator:nightl"),
             command=f"{command}",
             auto_remove=False,
             name=container_name,
@@ -117,3 +118,29 @@ class BambooGenerator(BaseGenerator):
 
     def check(self, content: str) -> bool:
         raise NotImplementedError("check_syntax() not implemented")
+
+    def run(self, job_id: str) -> None:
+        if self.output_settings.run_settings is None or self.output_settings.ci_credentials is None:
+            return
+        if self.final_result is None:
+            return
+        build_id: str = job_id.replace("/", "-")
+        logger.info("🔨", f"Triggering Bamboo build for {build_id}", self.output_settings.emoji)
+
+        # Endpoint to trigger the build
+        endpoint: str = f"{self.output_settings.ci_credentials.url}/rest/api/latest/queue/{build_id}"
+
+        # Make the request
+        headers: dict[str, str] = {"Authorization": f"Bearer {self.output_settings.ci_credentials.token}"}
+        params: dict[str, str] = {"bamboo.variable.lifecycle_stage": str(self.output_settings.run_settings.stage)}
+        response = requests.post(endpoint, headers=headers, params=params, timeout=30)
+
+        # Check the response
+        if response.status_code == 200:
+            logger.info("🔨", f"Triggered Bamboo build for {build_id} successfully", self.output_settings.emoji)
+        else:
+            logger.error(
+                "❌",
+                f"Failed to trigger Bamboo build for {build_id}, got {response.status_code}",
+                self.output_settings.emoji,
+            )

--- a/cli/generators/bamboo.py
+++ b/cli/generators/bamboo.py
@@ -1,5 +1,6 @@
 # pylint: disable=duplicate-code
 import base64
+import os
 import subprocess
 from typing import List
 from utils import logger
@@ -89,10 +90,10 @@ class BambooGenerator(BaseGenerator):
         container_name: str = "bambeolus"
         command: str = f"--base64 {base64_str}"
         if self.output_settings.ci_credentials is not None:
-            command += f" --publish --server {self.output_settings.ci_credentials.url}"
+            command += f" --publish --server {self.output_settings.ci_credentials.url} "
             command += f"--token {self.output_settings.ci_credentials.token}"
         client.containers.run(
-            image="ghcr.io/ls1intum/aeolus/bamboo-generator:nightly",
+            image=os.getenv("BAMBOO_GENERATOR_IMAGE", "ghcr.io/ls1intum/bamboo-generator:nightly"),
             command=f"{command}",
             auto_remove=False,
             name=container_name,

--- a/cli/generators/base.py
+++ b/cli/generators/base.py
@@ -18,6 +18,7 @@ class BaseGenerator:
     output_settings: OutputSettings
     metadata: PassMetadata
     result: typing.List[str]
+    final_result: typing.Optional[str]
 
     def __init__(
         self,
@@ -61,4 +62,11 @@ class BaseGenerator:
         """
         Generate the CI file.
         """
-        return "\n".join(self.result)
+        self.final_result = "\n".join(self.result)
+        return self.final_result
+
+    def run(self) -> None:
+        """
+        Run the resulting script.
+        """
+        raise NotImplementedError("run() not implemented")

--- a/cli/generators/base.py
+++ b/cli/generators/base.py
@@ -65,7 +65,7 @@ class BaseGenerator:
         self.final_result = "\n".join(self.result)
         return self.final_result
 
-    def run(self) -> None:
+    def run(self, job_id: str) -> None:
         """
         Run the resulting script.
         """

--- a/cli/generators/cli.py
+++ b/cli/generators/cli.py
@@ -1,4 +1,5 @@
 # pylint: disable=duplicate-code
+import os
 import subprocess
 import tempfile
 from typing import List, Optional
@@ -6,6 +7,9 @@ from typing import List, Optional
 from classes.generated.definitions import InternalAction, Repository
 from generators.base import BaseGenerator
 from utils import logger
+from docker.models.containers import Container  # type: ignore
+from docker.client import DockerClient  # type: ignore
+from docker.types.daemon import CancellableStream  # type: ignore
 
 
 class CliGenerator(BaseGenerator):
@@ -149,6 +153,44 @@ class CliGenerator(BaseGenerator):
         self.result.append(f"  git clone {repository.url} --branch {repository.branch} {directory}")
         self.result.append("}")
         self.functions.append(clone_method)
+
+    def run(self) -> None:
+        """
+        Run the generated bash script.
+        """
+        if self.output_settings.run_settings is None:
+            return
+        if self.final_result is None:
+            self.generate()
+        if self.final_result is None:
+            return
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            temp.write(self.generate().encode())
+            temp.flush()
+            client: DockerClient = DockerClient.from_env()
+            container_name: str = "aeolus-worker"
+            client.containers.run(
+                image="ghcr.io/ls1intum/aeolus/worker:nightly",
+                command=f"{self.output_settings.run_settings.stage}",
+                volumes={temp.name: {"bind": "/entrypoint.sh", "mode": "ro"}},
+                auto_remove=False,
+                name=container_name,
+                detach=True,
+            )
+            container: Container = client.containers.get(container_name)
+            logs: CancellableStream = container.logs(stream=True, stdout=True, stderr=True)
+            lines: List[str] = logs.next().decode("utf-8").split("\n")
+            while container.status == "running" or lines:
+                try:
+                    for line in lines:
+                        if line:
+                            print(line)
+                    lines = logs.next().decode("utf-8").split("\n")
+                except StopIteration:
+                    break
+            container.remove()
+            os.unlink(temp.name)
+        return
 
     def generate(self) -> str:
         """

--- a/cli/generators/jenkins.py
+++ b/cli/generators/jenkins.py
@@ -166,6 +166,23 @@ class JenkinsGenerator(BaseGenerator):
             self.result.append(f"{prefix}    }}")
         self.result.append("    }")
 
+    def run(self) -> None:
+        """
+        Run the pipeline in the Jenkins CI system.
+        :return: None
+        """
+        if self.windfile.metadata.id is None or self.output_settings.run_settings is None:
+            raise ValueError("Publishing requires an id")
+        if self.output_settings.ci_credentials is None:
+            raise ValueError("Publishing requires a CI URL and a token, with Jenkins we also need a username")
+        server = jenkins.Jenkins(
+            self.output_settings.ci_credentials.url,
+            username=self.output_settings.ci_credentials.username,
+            password=self.output_settings.ci_credentials.token,
+        )
+        job_name: str = self.windfile.metadata.id.replace("-", "/")
+        server.build_job(job_name, parameters={"current_lifecycle": self.output_settings.run_settings.stage})
+
     def publish(self) -> None:
         """
         Publish the pipeline to the Jenkins CI system.

--- a/cli/main.py
+++ b/cli/main.py
@@ -9,6 +9,7 @@ import sys
 from classes.ci_credentials import CICredentials
 from classes.input_settings import InputSettings
 from classes.output_settings import OutputSettings
+from classes.run_settings import RunSettings
 from commands.generate import Generate
 from commands.merge import Merge
 from commands.translate import Translate
@@ -17,6 +18,10 @@ from utils import utils
 
 
 def add_argparse() -> argparse.ArgumentParser:
+    """
+    Add arguments and subcommands to the argparser of the tool.
+    :return: argparser with arguments and subcommands
+    """
     arg_parser: argparse.ArgumentParser = argparse.ArgumentParser(
         prog="aeolus",
         description="Aeolus is a tool to manage your CI jobs. "
@@ -65,6 +70,11 @@ def add_argparse() -> argparse.ArgumentParser:
 
 
 def parse_args(arguments: list[str]) -> typing.Any:
+    """
+    Parse the given arguments.
+    :param arguments:
+    :return:
+    """
     argument_parser: argparse.ArgumentParser = add_argparse()
     return argument_parser.parse_args(arguments)
 
@@ -111,6 +121,17 @@ if __name__ == "__main__":
                 )
                 raise ValueError("Publishing requires a CI URL and a token, with Jenkins we also need a username")
             output_settings.ci_credentials = CICredentials(url=args.url, username=args.user, token=args.token)
+
+        if args.run is not None:
+            if args.target != "cli" and (not args.url or not args.token):
+                utils.logger.error(
+                    "❌ ",
+                    "Running is only supported for Jenkins and Bamboo"
+                    " if you use also pass a ci url (--url) and token (--token)",
+                    output_settings.emoji,
+                )
+                raise ValueError("Running is only supported with the CLI target")
+            output_settings.run_settings = RunSettings(stage=args.run)
 
         generator: Generate = Generate(
             input_settings=input_settings,

--- a/cli/main.py
+++ b/cli/main.py
@@ -139,6 +139,7 @@ if __name__ == "__main__":
             args=args,
         )
         generator.generate()
+
     if args.command == "translate":
         credentials: CICredentials = CICredentials(url=args.url, username=None, token=args.token)
         translator: Translate = Translate(

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,3 +1,7 @@
 FROM ubuntu:22.04 as cli-worker
 
-RUN apt update && apt install -y curl wget
+RUN apt update && apt install -y curl wget git
+
+WORKDIR /workdir
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
This PR adds support to directly run generated scripts in cli (using a provided docker container or the defined image in the metadata), or triggering a build in jenkins or bamboo.

Furthermore, the bamboo generator now uses a single stage if a docker container is being used and a single checkout task for all repositories. The dummy tasks are also not included from now on if no stage of the lifecycle of a PE is excluded