### PR TITLE
containers: replace deprecated openjdk baseimage

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim as jar-builder
+FROM docker.io/library/eclipse-temurin:17-jdk as jar-builder
 
 ADD bamboo-generator/ .
 RUN ./gradlew shadowJar --no-daemon -x :generateJsonSchema2Pojo

--- a/docker/bamboo-generator/Dockerfile
+++ b/docker/bamboo-generator/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:17-slim as jar-builder
+FROM docker.io/library/eclipse-temurin:17-jdk as jar-builder
 
 ADD bamboo-generator/ .
 RUN ./gradlew shadowJar --no-daemon -x :generateJsonSchema2Pojo
 RUN cp ./build/libs/bamboo-generator*-all.jar bamboo-generator.jar
 
-FROM openjdk:17-slim as runtime
+FROM docker.io/library/eclipse-temurin:17-jre as runtime
 
 COPY --from=jar-builder /bamboo-generator.jar bamboo-generator.jar
 EXPOSE 8091

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim as jar-builder
+FROM docker.io/library/eclipse-temurin:17-jdk as jar-builder
 
 ADD bamboo-generator/ .
 RUN ./gradlew shadowJar --no-daemon -x :generateJsonSchema2Pojo


### PR DESCRIPTION
The openjdk base image has been deprecated for some time: https://hub.docker.com/_/openjdk

This PR replaces its uses with eclipse-temurin.

CI failing since fork-PR has no permissions to push the images. The actual image build seems to work, though.